### PR TITLE
improvement(settings): add a required `parent_type` field

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -77,7 +77,7 @@ module PlaceOS::Model
     it "queries for a single parent_ids" do
       Settings.clear
 
-      id = "1234"
+      id = "sys-1234"
       settings = mock_data.map do |level, string|
         Settings.new(encryption_level: level, settings_string: string, parent_id: id).save!
       end.to_a
@@ -90,7 +90,7 @@ module PlaceOS::Model
     it "queries for a collection of parent_ids" do
       Settings.clear
 
-      mock_ids = Array.new(mock_data.size) { rand(9999).to_s }
+      mock_ids = Array.new(mock_data.size) { "sys-#{rand(9999)}" }
       settings = mock_data.zip(mock_ids).map do |(level, string), id|
         Settings.new(encryption_level: level, settings_string: string, parent_id: id).save!
       end.to_a


### PR DESCRIPTION
`parent_type` is to to improve resolution of setting dependencies

@MrYuion: when we a settings is created for a model set `parent_type` to one of `control_system|zone|module|driver`