### PR TITLE
fix(control-system): generate resolved module names

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 2.0.3
+version: 2.1.0
 
 dependencies:
   # Data validation library

--- a/spec/control_system_spec.cr
+++ b/spec/control_system_spec.cr
@@ -207,5 +207,16 @@ module PlaceOS::Model
 
       {cs, zone, zone2, trigger}.each &.destroy
     end
+
+    describe "features" do
+      it "includes modules resolved names on save" do
+        mod = Generator.module.save!
+        cs = Generator.control_system.save!
+        cs.modules = [mod.id].compact
+        cs.save!
+        cs.features.not_nil!.should contain(mod.resolved_name.as(String))
+        {cs, mod}.each &.destroy
+      end
+    end
   end
 end

--- a/src/placeos-models/control_system.cr
+++ b/src/placeos-models/control_system.cr
@@ -170,7 +170,7 @@ module PlaceOS::Model
         .compact_map(&.resolved_name)
         .select { |n| n != "__Triggers__" }
         .to_set
-      @features = @features.try &.+ module_names || module_names
+      @features = @features.try &.+(module_names) || module_names
     end
 
     # =======================

--- a/src/placeos-models/control_system.cr
+++ b/src/placeos-models/control_system.cr
@@ -94,7 +94,7 @@ module PlaceOS::Model
     # Obtains the control system's modules as json
     # FIXME: Dreadfully needs optimisation, i.e. subset serialisation
     def module_data
-      modules = @modules || [] of String
+      modules = self.modules || [] of String
       Module.find_all(modules).to_a.map do |mod|
         # Pick off driver name, and module_name from associated driver
         driver_data = mod.driver.try do |driver|
@@ -162,13 +162,16 @@ module PlaceOS::Model
 
     before_save :update_features
 
+    # Internal modules
+    private IGNORED_MODULES = ["__Triggers__"]
+
     # Adds modules to the features field,
     # Extends features with extra_features field in settings if present
     protected def update_features
       module_names = Module
         .find_all(@modules || [] of String)
         .compact_map(&.resolved_name)
-        .select { |n| n != "__Triggers__" }
+        .select(&.in?(IGNORED_MODULES).!)
         .to_set
       @features = @features.try &.+(module_names) || module_names
     end


### PR DESCRIPTION
ControlSystem features are now a Set(String). They should be maintained like Zone tags

@benhoad @MrYuion This change is relevant to PlaceOS/backoffice/issues/69

Fixes #28 