### PR TITLE
fix(authority): destroy dependent users, oauth strats, ldap strats, and saml strats

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 2.1.0
+version: 2.1.1
 
 dependencies:
   # Data validation library

--- a/spec/authority_spec.cr
+++ b/spec/authority_spec.cr
@@ -23,5 +23,35 @@ module PlaceOS::Model
       found = Authority.find_by_domain(domain)
       found.try(&.id).should eq authority.id
     end
+
+    describe "destroy relations" do
+      it "removes dependent saml authentications" do
+        auth = Generator.authority.save!
+        strat = Generator.adfs_strat(authority: auth).save!
+        auth.destroy
+        SamlAuthentication.find(strat.id.as(String)).should be_nil
+      end
+
+      it "removes dependent ldap authentications" do
+        auth = Generator.authority.save!
+        strat = Generator.ldap_strat(authority: auth).save!
+        auth.destroy
+        LdapAuthentication.find(strat.id.as(String)).should be_nil
+      end
+
+      it "removes dependent oauth authentications" do
+        auth = Generator.authority.save!
+        strat = Generator.oauth_strat(authority: auth).save!
+        auth.destroy
+        OAuthAuthentication.find(strat.id.as(String)).should be_nil
+      end
+
+      it "removes dependent users" do
+        auth = Generator.authority.save!
+        user = Generator.user(authority: auth).save!
+        auth.destroy
+        User.find(user.id.as(String)).should be_nil
+      end
+    end
   end
 end

--- a/spec/generator.cr
+++ b/spec/generator.cr
@@ -193,7 +193,7 @@ module PlaceOS::Model
         authority = existing || self.authority.save!
       end
 
-      AdfsStrat.new(
+      SamlAuthentication.new(
         name: Faker::Name.name,
         authority_id: authority.id,
         assertion_consumer_service_url: Faker::Internet.url,
@@ -208,7 +208,7 @@ module PlaceOS::Model
         authority = existing || self.authority.save!
       end
 
-      OauthStrat.new(
+      OAuthAuthentication.new(
         name: Faker::Name.name,
         authority_id: authority.id,
       )
@@ -221,7 +221,7 @@ module PlaceOS::Model
         authority = existing || self.authority.save!
       end
 
-      LdapStrat.new(
+      LdapAuthentication.new(
         name: Faker::Name.name,
         authority_id: authority.id,
         host: Faker::Internet.domain_name,

--- a/src/placeos-models/authority.cr
+++ b/src/placeos-models/authority.cr
@@ -1,6 +1,11 @@
 require "uri"
 require "json"
+
 require "./base/model"
+require "./ldap_authentication"
+require "./oauth_authentication"
+require "./saml_authentication"
+require "./user"
 
 module PlaceOS::Model
   class Authority < ModelBase
@@ -21,6 +26,20 @@ module PlaceOS::Model
     attribute config : Hash(String, JSON::Any) = {} of String => JSON::Any
 
     validates :name, presence: true
+
+    {% for relation, _idx in [
+                               {LdapAuthentication, "ldap_authentications"},
+                               {OAuthAuthentication, "oauth_authentications"},
+                               {SamlAuthentication, "saml_authentications"},
+                               {User, "users"},
+                             ] %}
+      has_many(
+        child_class: {{relation[0].id}},
+        collection_name: {{relation[1].stringify.id}},
+        foreign_key: "authority_id",
+        dependent: :destroy
+      )
+    {% end %}
 
     macro finished
       # Ensure we are only saving the host


### PR DESCRIPTION
Add `has_many` relation with `destroy` dependency to `PlaceOS::Model::Authority` for...
- `PlaceOS::Model::OAuthAuthentication`
- `PlaceOS::Model::LdapAuthentication`
- `PlaceOS::Model::SamlAuthentication`

Fixes #27 