### PR TITLE
refactor: use `case...in` over `case...when` where possible

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 3.0.5
+version: 3.0.6
 
 dependencies:
   # Data validation library

--- a/spec/generator.cr
+++ b/spec/generator.cr
@@ -80,25 +80,24 @@ module PlaceOS::Model
       driver = Generator.driver(module_name: mod_name) if driver.nil?
       driver.save! unless driver.persisted?
 
-      mod = case driver.role
-            when Driver::Role::Logic
+      mod = case driver.role.as(Driver::Role)
+            in .logic?
               Module.new(custom_name: mod_name, uri: Faker::Internet.url)
-            when Driver::Role::Device
+            in .device?
               Module.new(
                 custom_name: mod_name,
                 uri: Faker::Internet.url,
                 ip: Faker::Internet.ip_v4_address,
                 port: rand((1..6555)),
               )
-            when Driver::Role::SSH
+            in .ssh?
               Module.new(
                 custom_name: mod_name,
                 uri: Faker::Internet.url,
                 ip: Faker::Internet.ip_v4_address,
                 port: rand((1..65_535)),
               )
-            else
-              # Driver::Role::Service
+            in .service?, .websocket?
               Module.new(custom_name: mod_name, uri: Faker::Internet.url)
             end
 

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -189,28 +189,28 @@ module PlaceOS::Model
           settings.encrypt!
 
           case level
-          when Encryption::Level::None
+          in .none?
             settings.decrypt_for(user).should eq string
             settings.decrypt_for(support).should eq string
             settings.decrypt_for(admin).should eq string
             is_encrypted?(settings.decrypt_for(user)).should be_false
             is_encrypted?(settings.decrypt_for(support)).should be_false
             is_encrypted?(settings.decrypt_for(admin)).should be_false
-          when Encryption::Level::Support
+          in .support?
             settings.decrypt_for(user).should_not eq string
             settings.decrypt_for(support).should eq string
             settings.decrypt_for(admin).should eq string
             is_encrypted?(settings.decrypt_for(user)).should be_true
             is_encrypted?(settings.decrypt_for(support)).should be_false
             is_encrypted?(settings.decrypt_for(admin)).should be_false
-          when Encryption::Level::Admin
+          in .admin?
             settings.decrypt_for(user).should_not eq string
             settings.decrypt_for(support).should_not eq string
             settings.decrypt_for(admin).should eq string
             is_encrypted?(settings.decrypt_for(user)).should be_true
             is_encrypted?(settings.decrypt_for(support)).should be_true
             is_encrypted?(settings.decrypt_for(admin)).should be_false
-          when Encryption::Level::NeverDisplay
+          in .never_display?
             settings.decrypt_for(user).should_not eq string
             settings.decrypt_for(support).should_not eq string
             settings.decrypt_for(admin).should_not eq string

--- a/src/placeos-models/module.cr
+++ b/src/placeos-models/module.cr
@@ -133,12 +133,12 @@ module PlaceOS::Model
     #
     def hostname
       case role
-      when Driver::Role::SSH, Driver::Role::Device
+      in .ssh?, .device?
         self.ip
-      when Driver::Role::Service, Driver::Role::Websocket
+      in .service?, .websocket?
         uri = self.uri || self.driver.try &.default_uri
         uri.try(&->URI.parse(String)).try(&.host)
-      else
+      in .logic?
         # No hostname for Logic module
         nil
       end
@@ -171,11 +171,11 @@ module PlaceOS::Model
       return if driver.nil? || role.nil?
 
       case role
-      when Driver::Role::Service, Driver::Role::Websocket
+      in .service?, .websocket?
         this.validate_service_module(driver.role)
-      when Driver::Role::Logic
+      in .logic?
         this.validate_logic_module
-      when Driver::Role::Device, Driver::Role::SSH
+      in .device?, .ssh?
         this.validate_device_module
       end
     }

--- a/src/placeos-models/user_jwt.cr
+++ b/src/placeos-models/user_jwt.cr
@@ -54,18 +54,18 @@ module PlaceOS::Model
 
     def is_admin?
       case @user.permissions
-      when Permissions::Admin, Permissions::AdminSupport
+      in .admin?, .admin_support?
         true
-      else
+      in .user?, .support?
         false
       end
     end
 
     def is_support?
       case @user.permissions
-      when Permissions::Support, Permissions::Admin, Permissions::AdminSupport
+      in .support?, .admin?, .admin_support?
         true
-      else
+      in .user?
         false
       end
     end


### PR DESCRIPTION
Migrate to `case... in` statements where possible to ensure branch coverage of type unions and enums.