### PR TITLE
fix(settings): raise Model::Error on failed parse

### DIFF
--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -336,7 +336,7 @@ module PlaceOS::Model
         YAML.parse(settings_string).as_h
       end
     rescue
-      raise Error.new("Failed to parse YAML settings: #{settings_string}")
+      raise Model::Error.new("Failed to parse YAML settings: #{settings_string}")
     end
   end
 end


### PR DESCRIPTION
Previous `Error` reference was resolving to a Neuroplastic::Error
due to inclusing in ModelBase.

Authored by @KimBurgess 