### PR TITLE
fix(control_system): remove module from features in `remove_module`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 3.1.0
+version: 3.1.1
 
 dependencies:
   # Data validation library
@@ -10,6 +10,10 @@ dependencies:
   # Data validation library
   CrystalEmail:
     github: Nephos/CrystalEmail
+
+  # Simple async tasks
+  future:
+    github: crystal-community/future.cr
 
   # JSON Web Token support
   jwt:

--- a/spec/control_system_spec.cr
+++ b/spec/control_system_spec.cr
@@ -121,11 +121,14 @@ module PlaceOS::Model
         version = cs.version.as(Int32)
 
         cs.modules.not_nil!.should contain module_id
+        cs.features.not_nil!.should contain mod.resolved_name
 
         control_system.remove_module(module_id)
+        control_system.save!
 
         cs = ControlSystem.find!(control_system_id)
         cs.modules.not_nil!.should_not contain module_id
+        cs.features.not_nil!.should_not contain mod.resolved_name
         cs.version.should eq (version + 1)
 
         {control_system, driver, mod}.each &.destroy

--- a/src/placeos-models/control_system.cr
+++ b/src/placeos-models/control_system.cr
@@ -1,6 +1,7 @@
 require "rethinkdb-orm"
 require "time"
 require "uri"
+require "future"
 
 require "./base/model"
 require "./settings"
@@ -241,8 +242,10 @@ module PlaceOS::Model
     #
     def remove_module(module_id : String)
       mods = self.modules
+      mod = Module.find(module_id)
       if mods && mods.includes?(module_id) && ControlSystem.remove_module(id.as(String), module_id)
         mods.delete(module_id)
+        self.features.as(Set(String)).delete(mod.try &.resolved_name).delete(mod.try &.name)
         self.version = ControlSystem.table_query(&.get(id.as(String))["version"]).as_i
       end
     end

--- a/src/placeos-models/module.cr
+++ b/src/placeos-models/module.cr
@@ -1,4 +1,5 @@
 require "rethinkdb-orm"
+require "future"
 require "uri"
 
 require "./base/model"
@@ -251,17 +252,15 @@ module PlaceOS::Model
     protected def remove_module
       mod_id = self.id.as(String)
 
-      # TODO: log if there were failures
-      ControlSystem.table_query do |q|
-        q
-          .filter { |sys| sys["modules"].contains(mod_id) }
-          .update { |sys|
-            {
-              "modules" => sys["modules"].set_difference([mod_id]),
-              "version" => sys["version"] + 1,
-            }
+      ControlSystem
+        .raw_query(&.table(ControlSystem.table_name).filter { |sys| sys["modules"].contains(mod_id) })
+        .map do |sys|
+          sys.remove_module(mod_id)
+          # The `ControlSystem` will regenerate `features`
+          future {
+            sys.save!
           }
-      end
+        end.each &.get
     end
 
     # Set the name/role from the associated Driver


### PR DESCRIPTION
Pulls out `Module`'s `custom_name` and `name` from the `ControlSystem`'s `features` set, which is regenerated on save. 