### PR TITLE
fix/name-keyword-subfield

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.1.0
+version: 4.1.1
 
 dependencies:
   # Data validation library

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.0.0
+version: 4.1.0
 
 dependencies:
   # Data validation library

--- a/src/placeos-models/authority.cr
+++ b/src/placeos-models/authority.cr
@@ -13,7 +13,7 @@ module PlaceOS::Model
 
     table :authority
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
     attribute domain : String
     ensure_unique :domain, create_index: true

--- a/src/placeos-models/broker.cr
+++ b/src/placeos-models/broker.cr
@@ -18,7 +18,7 @@ module PlaceOS::Model
 
     enum_attribute auth_type : AuthType = AuthType::UserPassword
 
-    attribute name : String
+    attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
 
     attribute host : String

--- a/src/placeos-models/control_system.cr
+++ b/src/placeos-models/control_system.cr
@@ -15,7 +15,7 @@ module PlaceOS::Model
 
     table :sys
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
 
     # Room search meta-data

--- a/src/placeos-models/control_system.cr
+++ b/src/placeos-models/control_system.cr
@@ -180,7 +180,7 @@ module PlaceOS::Model
     protected def update_features
       module_names = Module
         .find_all(@modules || [] of String)
-        .compact_map(&.resolved_name)
+        .map(&.resolved_name)
         .select(&.in?(IGNORED_MODULES).!)
         .to_set
       @features = @features.try &.+(module_names) || module_names

--- a/src/placeos-models/doorkeeper_application.cr
+++ b/src/placeos-models/doorkeeper_application.cr
@@ -12,7 +12,7 @@ module PlaceOS::Model
 
     table :doorkeeper_app
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute secret : String
     attribute scopes : String = "public"
     attribute owner_id : String, es_type: "keyword"

--- a/src/placeos-models/driver.cr
+++ b/src/placeos-models/driver.cr
@@ -22,7 +22,7 @@ module PlaceOS::Model
       Logic     = 99
     end
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
 
     attribute default_uri : String?

--- a/src/placeos-models/ldap_authentication.cr
+++ b/src/placeos-models/ldap_authentication.cr
@@ -9,7 +9,7 @@ module PlaceOS::Model
 
     table :ldap_strat
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     belongs_to Authority, foreign_key: "authority_id"
 
     attribute port : Int32 = 636

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -12,7 +12,7 @@ module PlaceOS::Model
 
     table :metadata
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
     attribute details : JSON::Any
 

--- a/src/placeos-models/module.cr
+++ b/src/placeos-models/module.cr
@@ -162,8 +162,10 @@ module PlaceOS::Model
 
     # Use custom name if it is defined and non-empty, otherwise use module name
     #
-    def resolved_name
-      self.custom_name.try { |n| !n.empty? } ? self.custom_name : self.name
+    def resolved_name : String
+      custom = self.custom_name
+
+      custom.nil? || custom.empty? ? self.name : custom
     end
 
     validate ->(this : Module) {

--- a/src/placeos-models/oauth_authentication.cr
+++ b/src/placeos-models/oauth_authentication.cr
@@ -10,7 +10,7 @@ module PlaceOS::Model
 
     table :oauth_strat
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     belongs_to Authority, foreign_key: "authority_id"
 
     # The client ID and secret configured for this application

--- a/src/placeos-models/repository.cr
+++ b/src/placeos-models/repository.cr
@@ -21,7 +21,7 @@ module PlaceOS::Model
     end
 
     # Repository metadata
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute folder_name : String
     attribute description : String
     attribute uri : String

--- a/src/placeos-models/saml_authentication.cr
+++ b/src/placeos-models/saml_authentication.cr
@@ -9,7 +9,7 @@ module PlaceOS::Model
 
     table :adfs_strat
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     belongs_to Authority, foreign_key: "authority_id"
 
     # The name of your application

--- a/src/placeos-models/trigger.cr
+++ b/src/placeos-models/trigger.cr
@@ -10,7 +10,7 @@ module PlaceOS::Model
     include RethinkORM::Timestamps
     table :trigger
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
 
     # Full path allows resolution in macros

--- a/src/placeos-models/user.cr
+++ b/src/placeos-models/user.cr
@@ -12,7 +12,7 @@ module PlaceOS::Model
 
     belongs_to Authority
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute nickname : String = ""
     attribute email : String = ""
     attribute phone : String = ""

--- a/src/placeos-models/zone.cr
+++ b/src/placeos-models/zone.cr
@@ -12,7 +12,7 @@ module PlaceOS::Model
 
     table :zone
 
-    attribute name : String, es_type: "keyword"
+    attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
     attribute tags : Set(String) = ->{ Set(String).new }
 


### PR DESCRIPTION
Allows aggresive tokenization of `name` while preserving sort order via `name.keyword` subfield