### PR TITLE
feat(module): #logic_for query by parent control_system

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.2.6
+version: 4.3.0
 
 dependencies:
   # Data validation library

--- a/spec/module_spec.cr
+++ b/spec/module_spec.cr
@@ -48,6 +48,19 @@ module PlaceOS::Model
     end
 
     describe "locating modules" do
+      it "logic_for" do
+        control_system = Generator.control_system.save!
+        driver = Generator.driver(role: Driver::Role::Logic).save!
+
+        expected_ids = Array.new(2) {
+          Generator.module(driver: driver, control_system: control_system).save!.id.as(String)
+        }.sort
+
+        fetched_ids = Module.logic_for(control_system.id.as(String)).compact_map(&.id).to_a.sort
+
+        fetched_ids.should eq expected_ids
+      end
+
       it "in_zone" do
         control_system = Generator.control_system.save!
         begin

--- a/src/placeos-models/module.cr
+++ b/src/placeos-models/module.cr
@@ -68,6 +68,12 @@ module PlaceOS::Model
       ControlSystem.by_module_id(self.id)
     end
 
+    # Fetch `Module`s who have a direct parent `ControlSystem`
+    #
+    def self.logic_for(control_system_id : String)
+      Module.get_all([control_system_id], index: :control_system_id)
+    end
+
     def self.in_control_system(control_system_id : String)
       Module.raw_query do |q|
         q


### PR DESCRIPTION
adds `Module.logic_for(control_system_id : String)` to query for logic modules with a direct `ControlSystem` association