### PR TITLE
fix(module): ensure only logic modules have parent systems

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.5.3
+version: 4.5.4
 
 dependencies:
   # Data validation library

--- a/spec/module_spec.cr
+++ b/spec/module_spec.cr
@@ -45,6 +45,16 @@ module PlaceOS::Model
         # Preserves the existing modules
         control_system_modules.should contain(random_id)
       end
+
+      Driver::Role.values.reject(Driver::Role::Logic).each do |role|
+        it "invalidates a #{role} modules with a parent system" do
+          driver = Generator.driver(role: role)
+          mod = Generator.module(driver: driver)
+          mod.control_system_id = "cs-d0esN073xi57"
+          mod.valid?.should be_false
+          mod.errors.first.to_s.should eq "control_system should not be associated for #{role} modules"
+        end
+      end
     end
 
     describe "locating modules" do

--- a/src/placeos-models/module.cr
+++ b/src/placeos-models/module.cr
@@ -214,7 +214,14 @@ module PlaceOS::Model
       in .device?, .ssh?
         this.validate_device_module
       end
+
+      this.validate_no_parent_system unless this.role.logic?
     }
+
+    protected def validate_no_parent_system
+      has_control = !self.control_system_id.nil?
+      self.validation_error(:control_system, "should not be associated for #{self.role} modules") if has_control
+    end
 
     protected def validate_service_module(driver_role)
       self.role = driver_role
@@ -249,7 +256,7 @@ module PlaceOS::Model
       self.role = Driver::Role::Logic
       has_control = !self.control_system_id.nil?
 
-      self.validation_error(:control_system, "must be associated") unless has_control
+      self.validation_error(:control_system, "must be associated for logic modules") unless has_control
       self.validation_error(:edge, "logic module cannot be allocated to an edge") if self.on_edge?
     end
 


### PR DESCRIPTION
Adds a validator to `PlaceOS::Model::Module` to ensure only `Logic` modules have an associated parent system.