### PR TITLE
refactor: add presence for required associations

### DIFF
--- a/src/placeos-models/ldap_authentication.cr
+++ b/src/placeos-models/ldap_authentication.cr
@@ -10,7 +10,7 @@ module PlaceOS::Model
     table :ldap_strat
 
     attribute name : String, es_subfield: "keyword"
-    belongs_to Authority, foreign_key: "authority_id"
+    belongs_to Authority, foreign_key: "authority_id", presence: true
 
     attribute port : Int32 = 636
 
@@ -30,7 +30,6 @@ module PlaceOS::Model
     # Can be used instead of UID
     attribute filter : String?
 
-    validates :authority_id, presence: true
     validates :name, presence: true
     validates :host, presence: true
     validates :base, presence: true

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -23,13 +23,12 @@ module PlaceOS::Model
 
     secondary_index :parent_id
 
-    belongs_to Zone, foreign_key: "parent_id", association_name: "zone"
-    belongs_to ControlSystem, foreign_key: "parent_id", association_name: "control_system"
-    belongs_to User, foreign_key: "parent_id", association_name: "user"
+    belongs_to Zone, foreign_key: "parent_id", association_name: "zone", presence: true
+    belongs_to ControlSystem, foreign_key: "parent_id", association_name: "control_system", presence: true
+    belongs_to User, foreign_key: "parent_id", association_name: "user", presence: true
 
     validates :details, presence: true
     validates :name, presence: true
-    validates :parent_id, presence: true
 
     ensure_unique :name, scope: [:parent_id, :name] do |parent_id, name|
       {parent_id, name.strip.downcase}

--- a/src/placeos-models/oauth_authentication.cr
+++ b/src/placeos-models/oauth_authentication.cr
@@ -11,7 +11,7 @@ module PlaceOS::Model
     table :oauth_strat
 
     attribute name : String, es_subfield: "keyword"
-    belongs_to Authority, foreign_key: "authority_id"
+    belongs_to Authority, foreign_key: "authority_id", presence: true
 
     # The client ID and secret configured for this application
     attribute client_id : String
@@ -50,7 +50,6 @@ module PlaceOS::Model
     attribute raw_info_url : String?
 
     validates :name, presence: true
-    validates :authority_id, presence: true
 
     def type
       "oauths"

--- a/src/placeos-models/saml_authentication.cr
+++ b/src/placeos-models/saml_authentication.cr
@@ -10,7 +10,7 @@ module PlaceOS::Model
     table :adfs_strat
 
     attribute name : String, es_subfield: "keyword"
-    belongs_to Authority, foreign_key: "authority_id"
+    belongs_to Authority, foreign_key: "authority_id", presence: true
 
     # The name of your application
     attribute issuer : String = "place.technology"
@@ -63,7 +63,6 @@ module PlaceOS::Model
     # The value to use as default RelayState for single log outs
     attribute slo_default_relay_state : String?
 
-    validates :authority_id, presence: true
     validates :name, presence: true
     validates :issuer, presence: true
     validates :idp_sso_target_url, presence: true

--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -36,13 +36,12 @@ module PlaceOS::Model
       dependent: :destroy
     )
 
-    belongs_to ControlSystem, foreign_key: "parent_id"
-    belongs_to Driver, foreign_key: "parent_id"
-    belongs_to Module, foreign_key: "parent_id", association_name: "mod"
-    belongs_to Zone, foreign_key: "parent_id"
+    belongs_to ControlSystem, foreign_key: "parent_id", presence: true
+    belongs_to Driver, foreign_key: "parent_id", presence: true
+    belongs_to Module, foreign_key: "parent_id", association_name: "mod", presence: true
+    belongs_to Zone, foreign_key: "parent_id", presence: true
 
     validates :encryption_level, presence: true
-    validates :parent_id, presence: true
 
     # Possible parent documents
     enum ParentType
@@ -133,7 +132,7 @@ module PlaceOS::Model
       versions = Settings.raw_query do |r|
         r
           .table(Settings.table_name)
-          .get_all([parent_id.as(String)], index: :parent_id)
+          .get_all([parent_id], index: :parent_id)
           .filter({settings_id: id.as(String)})
           .order_by(r.desc(:created_at)).slice(slice_start, slice_end)
       end

--- a/src/placeos-models/user.cr
+++ b/src/placeos-models/user.cr
@@ -11,7 +11,7 @@ module PlaceOS::Model
     include RethinkORM::Timestamps
     table :user
 
-    belongs_to Authority
+    belongs_to Authority, presence: true
 
     attribute name : String, es_subfield: "keyword"
     attribute nickname : String = ""
@@ -63,7 +63,6 @@ module PlaceOS::Model
     # Validation
     ###############################################################################################
 
-    validates :authority_id, presence: true
     validates :email, presence: true
 
     validate ->(this : User) {


### PR DESCRIPTION
Removes the need to required association id's to `String` 