### PR TITLE
fix(edge): catch errors from invalid base64

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.12.0
+version: 4.12.1
 crystal: ~> 0.35
 
 dependencies:

--- a/src/placeos-models/edge.cr
+++ b/src/placeos-models/edge.cr
@@ -39,8 +39,9 @@ module PlaceOS::Model
     end
 
     def self.validate_token?(token : String) : String?
-      parts = Base64.decode_string(token).split('_')
-      unless parts.size == 2
+      parts = Base64.decode_string(token).split('_') rescue nil
+
+      if parts.nil? || parts.size != 2
         Log.info { {message: "deformed token", token: token} }
         return
       end


### PR DESCRIPTION
Catch errors raised by invalid base64 inputs to `Edge.validate_token?`