### PR TITLE
fix: to_reql

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.15.3
+version: 4.15.4
 crystal: ~> 1
 
 dependencies:

--- a/src/placeos-models/base/model.cr
+++ b/src/placeos-models/base/model.cr
@@ -24,7 +24,7 @@ module PlaceOS::Model
 
     # RethinkDB library serializes through JSON::Any
     def to_reql
-      JSON::Any.new(self.to_json)
+      JSON.parse(self.to_json)
     end
 
     # Propagate submodel validation errors to parent's

--- a/src/placeos-models/repository.cr
+++ b/src/placeos-models/repository.cr
@@ -16,7 +16,7 @@ module PlaceOS::Model
       Interface
 
       def to_reql
-        JSON::Any.new(to_s)
+        JSON::Any.new(to_s.downcase)
       end
     end
 


### PR DESCRIPTION
- `Repository::Type` was not correctly serialising via to `to_reql`
- `SubModel` was not serialising to a `JSON::Any`, fix utilises the unfortunate `JSON.parse(self.to_json)` hack out of necessity (correct serialisations, etc)
