### PR TITLE
fix: validate settings

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.15.5
+version: 4.16.0
 crystal: ~> 1
 
 dependencies:

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -1,5 +1,6 @@
 require "placeos-log-backend"
-::Log.setup("*", backend: PlaceOS::LogBackend.log_backend, level: Log::Severity::Debug)
+
+::Log.setup("*", backend: PlaceOS::LogBackend.log_backend, level: :trace)
 
 require "spec"
 require "random"

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -38,6 +38,24 @@ module PlaceOS::Model
       settings.keys.should be_empty
     end
 
+    describe "settings_string validation" do
+      it "rejects ill-formed JSON" do
+        settings = Generator.settings
+        settings.parent_type = :zone
+        settings.settings_string = "{"
+        settings.valid?.should be_false
+        settings.errors.first.to_s.should eq "settings_string is invalid JSON/YAML"
+      end
+
+      it "rejects ill-formed YAML" do
+        settings = Generator.settings
+        settings.parent_type = :zone
+        settings.settings_string = "hello:\n1"
+        settings.valid?.should be_false
+        settings.errors.first.to_s.should eq "settings_string is invalid JSON/YAML"
+      end
+    end
+
     it "encrypts on save" do
       unencrypted = %({"secret_key": "secret1234"})
       settings = Generator.settings(settings_string: unencrypted, encryption_level: Encryption::Level::Admin).save!

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -11,14 +11,7 @@ module PlaceOS::Model
   describe Settings do
     it "saves a settings" do
       settings = Generator.settings
-      begin
-        settings.save!
-      rescue e : RethinkORM::Error::DocumentInvalid
-        inspect_error(e)
-        raise e
-      end
-
-      settings.should_not be_nil
+      settings.save
       settings.persisted?.should be_true
       settings.id.as(String).should start_with "sets-"
     end
@@ -26,14 +19,7 @@ module PlaceOS::Model
     it "accepts empty settings strings" do
       settings = Generator.settings
       settings.settings_string = ""
-      begin
-        settings.save!
-      rescue e : RethinkORM::Error::DocumentInvalid
-        inspect_error(e)
-        raise e
-      end
-
-      settings.should_not be_nil
+      settings.save
       settings.persisted?.should be_true
       settings.keys.should be_empty
     end

--- a/src/placeos-models/edge.cr
+++ b/src/placeos-models/edge.cr
@@ -12,7 +12,7 @@ module PlaceOS::Model
 
     attribute description : String = ""
 
-    attribute secret : String = ->{ Random::Secure.base64(64) }, mass_assignment: false
+    attribute secret : String = ->{ Random::Secure.base64(64).delete('_') }, mass_assignment: false
 
     ENCRYPTION_LEVEL = Encryption::Level::Admin
 

--- a/src/placeos-models/error.cr
+++ b/src/placeos-models/error.cr
@@ -1,6 +1,9 @@
 module PlaceOS::Model
   class Error < Exception
     getter message
+
+    def initialize(@message = "", @cause = nil)
+    end
   end
 
   class NoParentError < Error

--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -334,8 +334,8 @@ module PlaceOS::Model
       else
         YAML.parse(settings_string).as_h
       end
-    rescue
-      raise Model::Error.new("Failed to parse YAML settings: #{settings_string}")
+    rescue e
+      raise Model::Error.new("Failed to parse YAML settings: #{settings_string}", cause: e)
     end
   end
 end

--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -45,6 +45,18 @@ module PlaceOS::Model
     validates :parent_id, presence: true
     validates :parent_type, presence: true
 
+    # Ensure `settings_string` is valid
+    validate ->(this : Settings) {
+      if this.settings_string_changed?
+        unencrypted = Encryption.is_encrypted?(this.settings_string) ? this.decrypt : this.settings_string
+        begin
+          YAML.parse(unencrypted) rescue JSON.parse(unencrypted)
+        rescue
+          this.validation_error(:settings_string, "is invalid JSON/YAML")
+        end
+      end
+    }
+
     # Possible parent documents
     enum ParentType
       ControlSystem


### PR DESCRIPTION
- Adds validation to `Setting#settings_string`
- Adds `cause` to `Model::Error` 
- Removes `_` char from `Edge#secret` on generation, this was interfering with the separator

Closes #76 