### PR TITLE
fix(edge): ensure seperator not present in secret or id

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.17.0
+version: 4.17.1
 crystal: ~> 1
 
 dependencies:

--- a/spec/edge_spec.cr
+++ b/spec/edge_spec.cr
@@ -28,14 +28,14 @@ module PlaceOS::Model
 
     describe "validate_token?" do
       it "validates a token, returning the edge_id" do
-        edge = Generator.edge.save!; Fiber.yield
+        edge = Generator.edge.save!
         token = edge.token(Generator.authenticated_user).not_nil!
         Edge.validate_token?(token).should eq edge.id
       end
 
       it "if token is malformed, it returns nil" do
         edge = Generator.edge.save!
-        token = "#{edge.id}_rubbish"
+        token = "#{edge.id}#{Edge::TOKEN_SEPERATOR}rubbish"
         Edge.validate_token?(token).should be_nil
       end
     end
@@ -44,7 +44,7 @@ module PlaceOS::Model
       edge = Generator.edge
       secret = edge.secret
       edge.save!
-      expected = Base64.urlsafe_encode "#{edge.id}_#{secret}"
+      expected = Base64.urlsafe_encode "#{edge.id}#{Edge::TOKEN_SEPERATOR}#{secret}"
       edge.token(Generator.authenticated_user).should eq expected
     end
   end


### PR DESCRIPTION
[Tests](https://github.com/PlaceOS/models/runs/2218430663#step:6:13) occasionally revealed a bug in the generation/validation of `PlaceOS::Model::Edge` secrets.
The cause was a clash in the separator (`_`) and chars in the database id. 

This PR ensures the database id is free from URL unsafe chars, and strips `~`, which is the new separator.

Closes #83 