### PR TITLE
refactor: factor comparison operators into an enum

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 4.18.2
+version: 5.0.0
 crystal: ~> 1
 
 dependencies:

--- a/spec/trigger_spec.cr
+++ b/spec/trigger_spec.cr
@@ -74,31 +74,17 @@ module PlaceOS::Model
       end
 
       it "validates comparison condition" do
-        model = Generator.trigger
-
-        valid = Trigger::Conditions::Comparison.new(
-          left: true,
-          operator: "and",
-          right: {
-            mod:    "anthropocene",
-            status: "{on: true}",
-            keys:   ["on"],
-          }
-        )
-        invalid = Trigger::Conditions::Comparison.new(
-          left: false,
-          operator: "asldkgjbn",
-          right: {
-            mod:    "anthropocene",
-            status: "{on: true}",
-            keys:   ["on"],
-          }
-        )
-        model.conditions.try &.comparisons = [valid, invalid]
-
-        model.valid?.should be_false
-        model.errors.size.should eq 1
-        model.errors.first.to_s.should end_with "operator is not included in the list"
+        expect_raises(JSON::SerializableError | JSON::MappingError) do
+          Trigger::Conditions::Comparison.from_json({
+            left:     false,
+            operator: "asldkgjbn",
+            right:    {
+              mod:    "anthropocene",
+              status: "{on: true}",
+              keys:   ["on"],
+            },
+          }.to_json)
+        end
       end
     end
   end

--- a/src/placeos-models/trigger/conditions.cr
+++ b/src/placeos-models/trigger/conditions.cr
@@ -27,14 +27,13 @@ module PlaceOS::Model
       alias Constant = Int64 | Float64 | String | Bool
 
       # Status of a Module
-      alias StatusVariable = NamedTuple(
+      record StatusVariable,
         # Module that defines the status variable
-        mod: String,
+        mod : String,
         # Unparsed hash of a status variable
-        status: String,
+        status : String,
         # Keys to look up in the module
-        keys: Array(String),
-      )
+        keys : Array(String) { include JSON::Serializable }
 
       enum Operator
         And


### PR DESCRIPTION
Move the comparison validation from set inclusion to language-level type safety via an enum. 
Also moves the `compare` method into the enum itself.