### PR TITLE
fix: ensure unique zone names

### DIFF
--- a/spec/control_system_spec.cr
+++ b/spec/control_system_spec.cr
@@ -17,6 +17,20 @@ module PlaceOS::Model
       cs.persisted?.should be_true
     end
 
+    it "no duplicate control system names" do
+      expect_raises(RethinkORM::Error::DocumentInvalid) do
+        name = RANDOM.base64(10)
+        cs1 = ControlSystem.new(
+          name: name,
+        )
+        cs1.save!
+        cs2 = ControlSystem.new(
+          name: name,
+        )
+        cs2.save!
+      end
+    end
+
     it "removes modules with only self as parent on destroy" do
       control_system = Generator.control_system
       control_system.save!

--- a/spec/zone_spec.cr
+++ b/spec/zone_spec.cr
@@ -18,6 +18,20 @@ module PlaceOS::Model
       zone.persisted?.should be_true
     end
 
+    it "no duplicate zone names" do
+      expect_raises(RethinkORM::Error::DocumentInvalid) do
+        name = RANDOM.base64(10)
+        zone1 = Zone.new(
+          name: name,
+        )
+        zone1.save!
+        zone2 = Zone.new(
+          name: name,
+        )
+        zone2.save!
+      end
+    end
+
     it "has unique tags" do
       zone = Generator.zone
       zone.tags << "hello"

--- a/src/placeos-models/zone.cr
+++ b/src/placeos-models/zone.cr
@@ -76,7 +76,9 @@ module PlaceOS::Model
     ###############################################################################################
 
     validates :name, presence: true
-    ensure_unique :name
+    ensure_unique :name do |name|
+      name.strip
+    end
 
     # Callbacks
     ###############################################################################################


### PR DESCRIPTION
Ensure Zones with existing names are not added and add some tests to confirm name uniqueness for Zones & Control Systems

Closes [PlaceOS/PlaceOS#70](https://github.com/PlaceOS/PlaceOS/issues/70) 