### PR TITLE
feat(doorkeeper): ensure uniqueness of name + URL

### DIFF
--- a/spec/doorkeeper_app_spec.cr
+++ b/spec/doorkeeper_app_spec.cr
@@ -4,7 +4,7 @@ module PlaceOS::Model
   describe DoorkeeperApplication do
     it "saves an app with a HTTP style" do
       app = DoorkeeperApplication.new
-      app.name = "test"
+      app.name = RANDOM.hex(10)
       app.redirect_uri = "http://test.redirect.com.au/#{RANDOM.hex(3)}"
       app.owner_id = RANDOM.hex(10)
 
@@ -19,9 +19,41 @@ module PlaceOS::Model
       app.uid.should eq(Digest::MD5.hexdigest(app.redirect_uri))
     end
 
+    it "no duplicate app uris" do
+      expect_raises(RethinkORM::Error::DocumentInvalid) do
+        uri = "appuri://test.redirect.com.au/#{RANDOM.hex(3)}"
+        app1 = DoorkeeperApplication.new
+        app1.name = RANDOM.hex(10)
+        app1.redirect_uri = uri
+        app1.owner_id = RANDOM.hex(10)
+        app1.save!
+        app2 = DoorkeeperApplication.new
+        app2.name = RANDOM.hex(10)
+        app2.redirect_uri = uri
+        app2.owner_id = RANDOM.hex(10)
+        app2.save!
+      end
+    end
+
+    it "no duplicate app names" do
+      expect_raises(RethinkORM::Error::DocumentInvalid) do
+        name = RANDOM.hex(3)
+        app1 = DoorkeeperApplication.new
+        app1.name = name
+        app1.redirect_uri = "appuri://test.redirect.com.au/#{RANDOM.hex(3)}"
+        app1.owner_id = RANDOM.hex(10)
+        app1.save!
+        app2 = DoorkeeperApplication.new
+        app2.name = name
+        app2.redirect_uri = "appuri://test.redirect.com.au/#{RANDOM.hex(3)}"
+        app2.owner_id = RANDOM.hex(10)
+        app2.save!
+      end
+    end
+
     it "saves an app with a random UID" do
       app = DoorkeeperApplication.new
-      app.name = "test"
+      app.name = RANDOM.hex(10)
       app.redirect_uri = "appuri://test.redirect.com.au/"
       app.owner_id = RANDOM.hex(10)
 
@@ -38,7 +70,7 @@ module PlaceOS::Model
 
     it "saves an app with a specified UID" do
       app = DoorkeeperApplication.new
-      app.name = "test"
+      app.name = RANDOM.hex(10)
       app.redirect_uri = "http://test.redirect.com.au/"
       app.uid = "my-special-uid"
       app.owner_id = RANDOM.hex(10)

--- a/src/placeos-models/doorkeeper_application.cr
+++ b/src/placeos-models/doorkeeper_application.cr
@@ -27,6 +27,14 @@ module PlaceOS::Model
 
     ensure_unique :uid, create_index: true
 
+    ensure_unique :redirect_uri do |redirect_uri|
+      redirect_uri.strip
+    end
+
+    ensure_unique :name do |name|
+      name.strip
+    end
+
     validates :name, presence: true
     validates :secret, presence: true
     validates :redirect_uri, presence: true


### PR DESCRIPTION
- Adds validation to ensure domains have applications with unique names and URLs
- Validation raises a more descriptive error message for the front end

Closes PlaceOS/rest-api#133