### PR TITLE
fix: set es-type for schema fields

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ dependencies:
 
   # Data validation library
   CrystalEmail:
-    github: Nephos/CrystalEmail
+    github: place-labs/CrystalEmail
 
   # Simple async tasks
   future:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 5.7.2
+version: 5.7.3
 crystal: ~> 1
 
 dependencies:

--- a/src/placeos-models/driver.cr
+++ b/src/placeos-models/driver.cr
@@ -14,7 +14,7 @@ module PlaceOS::Model
 
     attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
-    attribute json_schema : JSON::Any = JSON::Any.new({} of String => JSON::Any), converter: JSON::Any::StringConverter
+    attribute json_schema : JSON::Any = JSON::Any.new({} of String => JSON::Any), converter: JSON::Any::StringConverter, es_type: "text"
 
     attribute default_uri : String?
     attribute default_port : Int32?

--- a/src/placeos-models/json_schema.cr
+++ b/src/placeos-models/json_schema.cr
@@ -9,7 +9,7 @@ module PlaceOS::Model
 
     attribute name : String, es_subfield: "keyword"
     attribute description : String = ""
-    attribute schema : JSON::Any = JSON::Any.new({} of String => JSON::Any), converter: JSON::Any::StringConverter
+    attribute schema : JSON::Any = JSON::Any.new({} of String => JSON::Any), converter: JSON::Any::StringConverter, es_type: "text"
 
     has_many(
       child_class: Metadata,


### PR DESCRIPTION
`rubber-soul` was incorrectly mapping the type for the embedded objects `json_schema` and `schema` as we convert them to `JSON::Any` on serialisation from a raw string.

This PR adds type hints for `rubber-soul`