### PR TITLE
feat: add API key model

### DIFF
--- a/spec/api_key_spec.cr
+++ b/spec/api_key_spec.cr
@@ -1,7 +1,7 @@
 require "./helper"
 
 module PlaceOS::Model
-  describe Edge do
+  describe ApiKey do
     it "saves an API Token" do
       key = Generator.api_key.save!
 

--- a/spec/api_key_spec.cr
+++ b/spec/api_key_spec.cr
@@ -1,0 +1,68 @@
+require "./helper"
+
+module PlaceOS::Model
+  describe Edge do
+    it "saves an API Token", focus: true do
+      key = Generator.api_key.save!
+
+      key.should_not be_nil
+      key.persisted?.should be_true
+      ApiKey.find!(key.id.as(String)).id.should eq key.id
+      key.authority_id.should eq(key.user.not_nil!.authority_id)
+    end
+
+    it "hashes secrets on create" do
+      key = Generator.api_key
+      secret = key.secret
+      key.secret.should eq(secret)
+      key.save!
+      hashed = key.secret
+      hashed.should_not eq(secret)
+
+      # ensure it's not re-hashed on save
+      key.name += "bob"
+      key.save!
+      hashed.should eq(key.secret)
+    end
+
+    it "validates secrets" do
+      key = Generator.api_key
+      api_key = key.x_api_key
+      key.save!
+
+      found = ApiKey.find_key! api_key
+      found.id.should eq(key.id)
+
+      fake_id = "#{key.id}.notamatch"
+    end
+
+    it "generates a jwt object" do
+      key = Generator.api_key
+      jwt = key.build_jwt
+
+      jwt.iss.should eq("POS")
+      jwt.id.should eq(key.user_id)
+      jwt.domain.should eq(key.authority.not_nil!.domain)
+      jwt.scope.should eq(["public"])
+      user = key.user.not_nil!
+      jwt.user.name.should eq(user.name)
+      jwt.user.email.should eq(user.email)
+      jwt.user.roles.should eq(user.groups)
+      jwt.user.permissions.should eq(UserJWT::Permissions::User)
+
+      key.permissions = UserJWT::Permissions::Admin
+      jwt = key.build_jwt
+      jwt.user.permissions.should eq(UserJWT::Permissions::Admin)
+    end
+
+    it "cleans up when user is deleted" do
+      key = Generator.api_key
+      key.save!
+      id = key.id.as(String)
+      ApiKey.find!(id).id.should eq key.id
+
+      key.user.not_nil!.destroy
+      ApiKey.find(id).should be_nil
+    end
+  end
+end

--- a/spec/api_key_spec.cr
+++ b/spec/api_key_spec.cr
@@ -2,7 +2,7 @@ require "./helper"
 
 module PlaceOS::Model
   describe Edge do
-    it "saves an API Token", focus: true do
+    it "saves an API Token" do
       key = Generator.api_key.save!
 
       key.should_not be_nil
@@ -33,11 +33,15 @@ module PlaceOS::Model
       found = ApiKey.find_key! api_key
       found.id.should eq(key.id)
 
-      fake_id = "#{key.id}.notamatch"
+      expect_raises(RethinkORM::Error::DocumentNotFound) do
+        fake_id = "#{key.id}.notamatch"
+        ApiKey.find_key! fake_id
+      end
     end
 
     it "generates a jwt object" do
       key = Generator.api_key
+      key.save!
       jwt = key.build_jwt
 
       jwt.iss.should eq("POS")

--- a/spec/generator.cr
+++ b/spec/generator.cr
@@ -241,8 +241,10 @@ module PlaceOS::Model
 
     def self.api_key(authority : Authority? = nil, support : Bool = false, admin : Bool = false)
       user = self.user(authority, support, admin)
+      user.save!
       key = ApiKey.new
       key.name = Faker::Name.name
+      key.user = user
       key
     end
 

--- a/spec/generator.cr
+++ b/spec/generator.cr
@@ -239,6 +239,13 @@ module PlaceOS::Model
       user
     end
 
+    def self.api_key(authority : Authority? = nil, support : Bool = false, admin : Bool = false)
+      user = self.user(authority, support, admin)
+      key = ApiKey.new
+      key.name = Faker::Name.name
+      key
+    end
+
     def self.adfs_strat(authority : Authority? = nil)
       unless authority
         # look up an existing authority

--- a/src/placeos-models/api_key.cr
+++ b/src/placeos-models/api_key.cr
@@ -60,7 +60,6 @@ module PlaceOS::Model
     before_create :x_api_key
     before_create :hash!
 
-    # Reject '+' and '~'
     protected def safe_id
       self._new_flag = true
       @id ||= Random.new.hex(16)

--- a/src/placeos-models/api_key.cr
+++ b/src/placeos-models/api_key.cr
@@ -1,0 +1,107 @@
+require "random"
+require "crypto/bcrypt"
+
+require "./base/model"
+require "./user_jwt"
+
+module PlaceOS::Model
+  class ApiKey < ModelBase
+    include RethinkORM::Timestamps
+
+    table :api_key
+
+    attribute name : String, es_subfield: "keyword"
+    attribute description : String = ""
+    attribute scopes : Array(String) = ["public"]
+
+    # when nil it defaults to the users permissions
+    attribute permissions : UserJWT::Permissions? = nil
+
+    attribute secret : String = ->{ Random::Secure.urlsafe_base64(32) }, mass_assignment: false
+
+    belongs_to User
+    belongs_to Authority
+
+    def user=(user : User)
+      self.authority_id = user.authority_id
+      super(user)
+    end
+
+    secondary_index :authority_id
+
+    # Validation
+    ###############################################################################################
+
+    # Ensure name is unique under the authority scope
+    #
+    ensure_unique :name, scope: [:authority_id, :name] do |authority_id, name|
+      {authority_id, name.strip.downcase}
+    end
+
+    # Callbacks
+    ###############################################################################################
+
+    before_create :safe_id
+    before_create :set_authority
+    before_create :hash!
+
+    # Reject '+' and '~'
+    protected def safe_id
+      self._new_flag = true
+      @id ||= RethinkORM::IdGenerator.next(self).gsub({"+": '-', "~": '-'}).split('-', 2)[1]
+      @id
+    end
+
+    protected def set_authority
+      self.authority_id = self.user.not_nil!.authority_id.not_nil!
+    end
+
+    # obscure the API key
+    protected def hash!
+      self.secret = Crypto::Bcrypt.new(self.secret, self.id.not_nil!).digest.hexstring
+      self
+    end
+
+    # Token Methods
+    ###############################################################################################
+
+    def x_api_key
+      raise "API key has already been hashed" if self.persisted?
+      "#{self.safe_id}.#{self.secret}"
+    end
+
+    def self.find_key!(token : String)
+      id, secret = token.split('.', 2)
+
+      model = Model::ApiKey.find!(id)
+
+      # Same error as being unable to find the model
+      if model.secret != Crypto::Bcrypt.new(secret, id).digest.hexstring
+        raise RethinkORM::Error::DocumentNotFound.new("Key not present: #{id}")
+      end
+
+      model
+    end
+
+    ISSUER = "POS"
+
+    def build_jwt
+      ident = self.user.not_nil!
+
+      UserJWT.new(
+        iss: ISSUER,
+        iat: 5.minutes.ago,
+        exp: 1.hour.from_now,
+        domain: self.authority.not_nil!.domain,
+        scope: self.scopes,
+        id: ident.id.not_nil!,
+        user: UserJWT::Metadata.new(
+          name: ident.name.not_nil!,
+          email: ident.email.not_nil!,
+          permissions: self.permissions || ident.to_jwt_permission,
+          roles: ident.groups.not_nil!
+        ),
+      )
+    end
+  end
+end

--- a/src/placeos-models/api_key.cr
+++ b/src/placeos-models/api_key.cr
@@ -22,14 +22,14 @@ module PlaceOS::Model
     belongs_to User
     belongs_to Authority
 
-    def user=(user)
-      super(user)
-      self.authority_id = user.authority_id
-    end
-
     secondary_index :authority_id
 
     macro finished
+      def user=(user)
+        super(user)
+        self.authority_id = user.authority_id
+      end
+
       def permissions
         @permissions || self.user.try &.to_jwt_permission
       end

--- a/src/placeos-models/api_key.cr
+++ b/src/placeos-models/api_key.cr
@@ -40,8 +40,8 @@ module PlaceOS::Model
 
     define_to_json :public, only: [
       :name, :description, :scopes, :user_id, :authority_id, :created_at,
-      :updated_at, :id,
-    ], methods: [:user, :authority, :x_api_key, :permissions]
+      :updated_at,
+    ], methods: [:user, :authority, :x_api_key, :permissions, :id]
 
     # Validation
     ###############################################################################################

--- a/src/placeos-models/edge.cr
+++ b/src/placeos-models/edge.cr
@@ -95,7 +95,7 @@ module PlaceOS::Model
     # Decrypt all encrypted attributes
     def decrypt_for!(user)
       self.secret = decrypt_secret_for(user)
-      sself
+      self
     end
 
     def check_secret?(test : String) : Bool

--- a/src/placeos-models/user.cr
+++ b/src/placeos-models/user.cr
@@ -269,7 +269,7 @@ module PlaceOS::Model
     ADMIN_DATA = {{
                    PUBLIC_DATA + [
                      :sys_admin, :support, :email, :phone, :ui_theme, :misc, :login_name,
-                     :staff_id, :card_number, :authority_id,
+                     :staff_id, :card_number,
                    ]
                  }}
     {% end %}

--- a/src/placeos-models/user.cr
+++ b/src/placeos-models/user.cr
@@ -6,6 +6,7 @@ require "rethinkdb-orm/lock"
 
 require "./authority"
 require "./base/model"
+require "./api_key"
 
 module PlaceOS::Model
   class User < ModelBase
@@ -54,9 +55,9 @@ module PlaceOS::Model
 
     has_many(
       child_class: UserAuthLookup,
-      dependent: :destroy,
+      collection_name: "auth_lookups",
       foreign_key: "user_id",
-      collection_name: :auth_lookups
+      dependent: :destroy,
     )
 
     # Metadata belonging to this user
@@ -64,6 +65,13 @@ module PlaceOS::Model
       child_class: Metadata,
       collection_name: "metadata",
       foreign_key: "parent_id",
+      dependent: :destroy
+    )
+
+    has_many(
+      child_class: ApiKey,
+      collection_name: "api_tokens",
+      foreign_key: "user_id",
       dependent: :destroy
     )
 
@@ -196,6 +204,10 @@ module PlaceOS::Model
       support
     end
 
+    def to_jwt_permission : UserJWT::Permissions
+      is_admin? ? UserJWT::Permissions::Admin : (is_support? ? UserJWT::Permissions::Support : UserJWT::Permissions::User)
+    end
+
     # NOTE: required due to use of `JSON.mapping` macro by `active-model`
     macro finished
       # Ensure the `PlaceOS::Model::User`'s `PlaceOS::Model::Authority` doesn't change
@@ -250,14 +262,14 @@ module PlaceOS::Model
 
     PUBLIC_DATA = [
       :email_digest, :nickname, :name, :first_name, :last_name, :groups,
-      :country, :building, :image, :created_at,
+      :country, :building, :image, :created_at, :authority_id,
     ]
 
     {% begin %}
     ADMIN_DATA = {{
                    PUBLIC_DATA + [
                      :sys_admin, :support, :email, :phone, :ui_theme, :misc, :login_name,
-                     :staff_id, :card_number,
+                     :staff_id, :card_number, :authority_id,
                    ]
                  }}
     {% end %}


### PR DESCRIPTION
allows generation of an API key where the key is never saved in the database for security

The idea is that the token generates a decoded JWT token that will be used against the controllers - so only a minor change to the authentication layer is required