### PR TITLE
feat(user): perform a case insensitive email lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All changes are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
+
+## [5.9.0](https://github.com/PlaceOS/models/compare/v5.8.1...v5.9.0)
+
+### Changed
+
+* **user**
+  * Email look-ups are case insensitve and made via `email_digest`([1f42e7c](https://github.com/PlaceOS/models/commit/1f42e7c))

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 5.8.1
+version: 5.9.0
 crystal: ~> 1
 
 dependencies:


### PR DESCRIPTION
Related to https://github.com/PlaceOS/models/issues/108

## Changed
* **user:**
  * `User.find_by_email` and `User.find_by_emails` are now case-insensitive.