### PR TITLE
fix(user): use SHA256 instead of MD5

### DIFF
--- a/spec/user_spec.cr
+++ b/spec/user_spec.cr
@@ -1,5 +1,3 @@
-require "digest/md5"
-
 require "./helper"
 
 module PlaceOS::Model
@@ -12,7 +10,7 @@ module PlaceOS::Model
 
       it "sets email digest on save" do
         user = Generator.user
-        expected_digest = Digest::MD5.hexdigest(user.email)
+        expected_digest = User.digest(user.email)
 
         user.email_digest.should be_nil
         user.save!

--- a/src/placeos-models/user.cr
+++ b/src/placeos-models/user.cr
@@ -1,6 +1,6 @@
 require "CrystalEmail"
 require "crypto/bcrypt/password"
-require "digest/md5"
+require "digest/sha256"
 require "rethinkdb-orm"
 require "rethinkdb-orm/lock"
 
@@ -151,7 +151,11 @@ module PlaceOS::Model
     # Sets email_digest to allow user look up without leaking emails
     #
     protected def create_email_digest
-      self.email_digest = Digest::MD5.hexdigest(self.email)
+      self.email_digest = self.class.digest(self.email)
+    end
+
+    def self.digest(string : String)
+      Digest::SHA256.hexdigest(string)
     end
 
     # Queries


### PR DESCRIPTION
Closes #112 

MD5 remains in use for the hash of the redirect in [`doorkeeper_application.cr`](https://github.com/PlaceOS/models/blob/master/src/placeos-models/doorkeeper_application.cr#L54)