### PR TITLE
fix(generator:metadata): typo

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 5.12.1
+version: 5.12.2
 crystal: ~> 1
 
 dependencies:

--- a/spec/generator.cr
+++ b/spec/generator.cr
@@ -154,11 +154,11 @@ module PlaceOS::Model
 
       case parent
       in ControlSystem
-        meta.control_system = control_system
+        meta.control_system = parent
       in String
         meta.parent_id = parent
       in Zone
-        meta.zone = zone
+        meta.zone = parent
       in Nil
         # Generate a single parent for the metadata model
         {


### PR DESCRIPTION
Typo when setting the parent on metadata