### PR TITLE
fix(settings): merge down encryption levels

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: placeos-models
-version: 5.15.3
-crystal: ~> 1
+version: 6.0.0
+crystal: ~> 1.0
 
 dependencies:
   # Data validation library

--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -213,7 +213,6 @@ module PlaceOS::Model
       cursor
         .to_a
         .sort_by!(&.encryption_level)
-        .reverse!
     end
 
     # Query all settings under `parent_id`
@@ -297,8 +296,8 @@ module PlaceOS::Model
           .sort_by(&.encryption_level)
           # Attain (if exists) setting for given key
           .compact_map(&.any[key]?)
-          # Get the highest privilege setting
-          .last
+          # Get the lowest privilege setting
+          .first
       end
     end
 

--- a/src/placeos-models/utilities/settings_helper.cr
+++ b/src/placeos-models/utilities/settings_helper.cr
@@ -29,16 +29,18 @@ module PlaceOS::Model
 
     # Decrypts and merges all settings for the model
     #
+    # Lower privilged settings are favoured during the merge process.
     def all_settings : Hash(YAML::Any, YAML::Any)
-      master_settings.reduce({} of YAML::Any => YAML::Any) do |acc, settings|
-        # Parse and merge into accumulated settings hash
-        begin
-          acc.merge!(settings.any)
-        rescue error
-          Log.warn(exception: error) { "failed to merge all settings: #{settings.inspect}" }
+      master_settings
+        .reverse!
+        .each_with_object({} of YAML::Any => YAML::Any) do |settings, acc|
+          # Parse and merge into accumulated settings hash
+          begin
+            acc.merge!(settings.any)
+          rescue error
+            Log.warn(exception: error) { "failed to merge all settings: #{settings.inspect}" }
+          end
         end
-        acc
-      end
     end
 
     # Decrypted JSON object for configuring drivers


### PR DESCRIPTION
Technically this is a breaking change.
However, it is more expected behaviour.

Previously, an encrypted value could silently override a setting of lower privilege.

Closes #119 