### PR TITLE
refactor!(error): better namespacing for errors

### DIFF
--- a/spec/api_key_spec.cr
+++ b/spec/api_key_spec.cr
@@ -4,14 +4,14 @@ module PlaceOS::Model
   describe ApiKey do
     describe ".saas_api_key" do
       it "checks for existing domain" do
-        expect_raises(SaasKeyError) do
+        expect_raises(Error::InvalidSaasKey) do
           ApiKey.saas_api_key(instance_domain: "does-not-exist", instance_email: "definitely-does-not-exist")
         end
       end
 
       it "checks for existing email" do
         authority = Generator.authority.save!
-        expect_raises(SaasKeyError) do
+        expect_raises(Error::InvalidSaasKey) do
           ApiKey.saas_api_key(instance_domain: authority.domain, instance_email: "does-not-exist")
         end
       end
@@ -27,7 +27,7 @@ module PlaceOS::Model
         key.user = user
         key.save!
 
-        expect_raises(SaasKeyError) do
+        expect_raises(Error::InvalidSaasKey) do
           ApiKey.saas_api_key(instance_domain: authority.domain, instance_email: user.email)
         end
       end

--- a/src/placeos-models/api_key.cr
+++ b/src/placeos-models/api_key.cr
@@ -121,14 +121,14 @@ module PlaceOS::Model
     # Used to delegate control of the instance by the PortalAPI.
     def self.saas_api_key(instance_domain, instance_email) : String
       unless authority = Model::Authority.find_by_domain(instance_domain)
-        raise SaasKeyError.new("authority does not exist for #{instance_domain}")
+        raise Model::Error::InvalidSaasKey.new("authority does not exist for #{instance_domain}")
       end
 
       authority_id = authority.id.as(String)
 
       # Fetch token for instance user
       unless user = Model::User.find_by_email(authority_id, instance_email)
-        raise SaasKeyError.new("instance user does not exist for #{instance_email}")
+        raise Model::Error::InvalidSaasKey.new("instance user does not exist for #{instance_email}")
       end
 
       user_id = user.id.as(String)
@@ -152,7 +152,7 @@ module PlaceOS::Model
         } }
         token
       else
-        raise SaasKeyError.new("key already exists for #{instance_email} on #{instance_domain}")
+        raise Model::Error::InvalidSaasKey.new("key already exists for #{instance_email} on #{instance_domain}")
       end
     end
   end

--- a/src/placeos-models/error.cr
+++ b/src/placeos-models/error.cr
@@ -4,20 +4,20 @@ module PlaceOS::Model
 
     def initialize(@message = "", @cause = nil)
     end
-  end
 
-  class NoParentError < Error
-  end
+    class NoParent < Error
+    end
 
-  class SaasKeyError < Error
-  end
+    class InvalidSaasKey < Error
+    end
 
-  class NoScope < Error
-  end
+    class NoScope < Error
+    end
 
-  class MalformedFilter < Error
-    def initialize(filters : Array(String)?)
-      super("One or more invalid regexes: #{filters}")
+    class MalformedFilter < Error
+      def initialize(filters : Array(String)?)
+        super("One or more invalid regexes: #{filters}")
+      end
     end
   end
 end

--- a/src/placeos-models/module.cr
+++ b/src/placeos-models/module.cr
@@ -273,7 +273,7 @@ module PlaceOS::Model
     #
     protected def set_name_and_role
       driver_ref = driver
-      raise NoParentError.new("Module<#{id}> missing parent Driver") unless driver_ref
+      raise Model::Error::NoParent.new("Module<#{id}> missing parent Driver") unless driver_ref
 
       self.role = driver_ref.role
       self.name = driver_ref.module_name

--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -133,7 +133,7 @@ module PlaceOS::Model
         raise Model::Error.new("Failed to parse Settings' parent type from #{parent_id}")
       end
     rescue e : NilAssertionError
-      raise NoParentError.new("Missing required parent for Settings<#{id}>")
+      raise Model::Error::NoParent.new("Missing required parent for Settings<#{id}>")
     end
 
     # Generate keys for settings object
@@ -228,7 +228,7 @@ module PlaceOS::Model
     ###########################################################################
 
     protected def encrypt(string : String)
-      raise NoParentError.new if (encryption_id = parent_id).nil?
+      raise Model::Error::NoParent.new if (encryption_id = parent_id).nil?
 
       Encryption.encrypt(string, level: encryption_level, id: encryption_id)
     end
@@ -249,7 +249,7 @@ module PlaceOS::Model
     # Decrypts the model's setting string
     #
     protected def decrypt
-      raise NoParentError.new if (encryption_id = parent_id).nil?
+      raise Model::Error::NoParent.new if (encryption_id = parent_id).nil?
 
       Encryption.decrypt(string: settings_string, level: encryption_level, id: encryption_id)
     end
@@ -264,7 +264,7 @@ module PlaceOS::Model
     # Decrypts (if user has correct privilege) and returns the settings string
     #
     def decrypt_for(user) : String
-      raise NoParentError.new unless (encryption_id = parent_id)
+      raise Model::Error::NoParent.new unless (encryption_id = parent_id)
 
       Encryption.decrypt_for(user: user, string: settings_string, level: encryption_level, id: encryption_id)
     end


### PR DESCRIPTION
A breaking change.

This places all errors beneath `PlaceOS::Model::Error`