### PR TITLE
fix(settings): return previous order of settings

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 6.0.0
+version: 6.0.1
 crystal: ~> 1.0
 
 dependencies:

--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -212,7 +212,10 @@ module PlaceOS::Model
 
       cursor
         .to_a
-        .sort_by!(&.encryption_level)
+        .sort_by! do |setting|
+          # Reversed
+          -1 * setting.encryption_level.value
+        end
     end
 
     # Query all settings under `parent_id`

--- a/src/placeos-models/utilities/settings_helper.cr
+++ b/src/placeos-models/utilities/settings_helper.cr
@@ -32,7 +32,6 @@ module PlaceOS::Model
     # Lower privilged settings are favoured during the merge process.
     def all_settings : Hash(YAML::Any, YAML::Any)
       master_settings
-        .reverse!
         .each_with_object({} of YAML::Any => YAML::Any) do |settings, acc|
           # Parse and merge into accumulated settings hash
           begin


### PR DESCRIPTION
#137 introduced a change that messed up the order settings were returned in via `#master_settings_query`.