### PR TITLE
fix(api_key): no error if SaaS key already exists, add `public` scope

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,10 @@
+name: Changelog
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  generate:
+    uses: PlaceOS/.github/.github/workflows/changelog.yml@main

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,6 @@
+name: Validate PR
+on: pull_request
+
+jobs:
+  title:
+    uses: PlaceOS/.github/.github/workflows/validate-pr-title.yml@main

--- a/spec/api_key_spec.cr
+++ b/spec/api_key_spec.cr
@@ -35,7 +35,7 @@ module PlaceOS::Model
       it "creates a key by domain and email" do
         authority = Generator.authority.save!
         user = Generator.user(authority).save!
-        token = ApiKey.saas_api_key(instance_domain: authority.domain, instance_email: user.email)
+        token = ApiKey.saas_api_key(instance_domain: authority.domain, instance_email: user.email).not_nil!
         ApiKey.find_key!(token).should be_a(ApiKey)
       end
     end

--- a/spec/api_key_spec.cr
+++ b/spec/api_key_spec.cr
@@ -27,9 +27,9 @@ module PlaceOS::Model
         key.user = user
         key.save!
 
-        expect_raises(Error::InvalidSaasKey) do
-          ApiKey.saas_api_key(instance_domain: authority.domain, instance_email: user.email)
-        end
+        ApiKey
+          .saas_api_key(instance_domain: authority.domain, instance_email: user.email)
+          .should eq(key.x_api_key)
       end
 
       it "creates a key by domain and email" do

--- a/spec/api_key_spec.cr
+++ b/spec/api_key_spec.cr
@@ -21,7 +21,7 @@ module PlaceOS::Model
         user = Generator.user(authority).save!
         key = ApiKey.new(
           name: "test",
-          scopes: [UserJWT::Scope::SAAS]
+          scopes: [UserJWT::Scope::SAAS, UserJWT::Scope::PUBLIC]
         )
         key.authority = authority
         key.user = user

--- a/spec/api_key_spec.cr
+++ b/spec/api_key_spec.cr
@@ -29,7 +29,7 @@ module PlaceOS::Model
 
         ApiKey
           .saas_api_key(instance_domain: authority.domain, instance_email: user.email)
-          .should eq(key.x_api_key)
+          .should be_nil
       end
 
       it "creates a key by domain and email" do

--- a/src/placeos-models/api_key.cr
+++ b/src/placeos-models/api_key.cr
@@ -119,7 +119,7 @@ module PlaceOS::Model
 
     # Builds an API token for a SaaS instance.
     # Used to delegate control of the instance by the PortalAPI.
-    def self.saas_api_key(instance_domain, instance_email) : String
+    def self.saas_api_key(instance_domain, instance_email) : String?
       unless authority = Model::Authority.find_by_domain(instance_domain)
         raise Model::Error::InvalidSaasKey.new("authority does not exist for #{instance_domain}")
       end
@@ -154,11 +154,11 @@ module PlaceOS::Model
         token
       else
         Log.info { {
-          message:         "using existing SaaS API key",
+          message:         "existing SaaS API key",
           instance_domain: instance_domain,
           instance_email:  instance_email,
         } }
-        existing_key.x_api_key.as(String)
+        nil
       end
     end
   end


### PR DESCRIPTION
**Description of the change**

Fetch the SaaS key even if it is already present in the remote.