### PR TITLE
feat(metadata): add `#history`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ The database models for [PlaceOS](https://place.technology/) in [crystal](https:
 PlaceOS is a distributed application, with many concurrent event sources that require persistence.
 We use [RethinkDB](https://rethinkdb.com) to unify our database and event bus, giving us a consistent interface to state and events across the system.
 
+## Configuration
+
+### Environment
+
+| Key                       | Description                                    | Default     |
+| ------------------------- | ---------------------------------------------- | ----------- |
+| `PLACE_MAX_VERSIONS`      | Number of versions to keep of versioned models | 20          |
+| `RETHINKDB_HOST`          | RethinkDB host                                 | "localhost" |
+| `RETHINKDB_PORT`          | RethinkDB port                                 | 28015       |
+| `RETHINKDB_DB`            | Database name                                  | "test"      |
+| `RETHINKDB_USER`          | Database user                                  | "admin"     |
+| `RETHINKDB_PASSWORD`      | Database password                              | ""          |
+| `RETHINKDB_TIMEOUT`       | Retry interval in seconds                      | 2           |
+| `RETHINKDB_RETRIES`       | Times to reattempt failed driver operations    | 10          |
+| `RETHINKDB_QUERY_RETRIES` | Times to reattempt failed queries              | 10          |
+| `RETHINKDB_LOCK_EXPIRE`   | Expiry on locks in seconds                     | 30          |
+| `RETHINKDB_LOCK_TIMEOUT`  | Timeout on retrying a lock in seconds          | 5           |
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md).

--- a/spec/metadata_spec.cr
+++ b/spec/metadata_spec.cr
@@ -6,7 +6,8 @@ module PlaceOS::Model
       control_system = Generator.control_system.save!
       meta = Generator.metadata(name: "test", parent: control_system.id.as(String)).save!
 
-      control_system.metadata.first.id.should eq meta.id
+      control_system.master_metadata.first.id.should eq meta.id
+
       meta_find = Metadata.find!(meta.id.as(String))
       meta_find.control_system!.id.should eq control_system.id
 
@@ -31,7 +32,7 @@ module PlaceOS::Model
       zone = Generator.zone.save!
       meta = Generator.metadata(parent: zone.id.as(String)).save!
 
-      zone.metadata.first.id.should eq meta.id
+      zone.master_metadata.first.id.should eq meta.id
       meta_find = Metadata.find!(meta.id.as(String))
       meta_find.zone!.id.should eq zone.id
 
@@ -55,28 +56,65 @@ module PlaceOS::Model
       Metadata.from_json(meta.to_json).details.should eq JSON.parse(object)
     end
 
-    describe "for" do
-      it "fetches metadata for a parent" do
-        parent = Generator.zone.save!
-        parent_id = parent.id.as(String)
-        5.times do
-          Generator.metadata(parent: parent_id).save!
+    describe "#history" do
+      it "renders versions made on updates to the master Metadata" do
+        changes = [0, 1, 2, 3].map { |i| JSON::Any.new({"test" => JSON::Any.new(i.to_i64)}) }
+        metadata = Generator.metadata
+        metadata.details = changes.first
+        metadata.save!
+
+        changes[1..].each_with_index(offset: 1) do |detail, i|
+          Timecop.freeze(i.seconds.from_now) do
+            metadata.details = detail
+            metadata.save!
+          end
         end
-        Metadata.for(parent_id).to_a.size.should eq 5
-        parent.destroy
+
+        metadata.history.map(&.details.as_h["test"]).should eq [3, 2, 1, 0]
+      end
+
+      it "limits number of stored versions" do
+        changes = Array(JSON::Any).new(2 * Utilities::Versions::MAX_HISTORY) { |i|
+          JSON::Any.new({"test" => JSON::Any.new(i.to_i64)})
+        }
+
+        metadata = Generator.metadata
+        metadata.details = changes.first
+        metadata.save!
+
+        changes[1..].each_with_index(offset: 1) do |detail, i|
+          Timecop.freeze(i.seconds.from_now) do
+            metadata.details = detail
+            metadata.save!
+          end
+        end
+
+        metadata.history.size.should eq Utilities::Versions::MAX_HISTORY
       end
     end
+  end
 
-    describe "build_metadata" do
-      it "builds a response of metadata for a parent" do
-        parent = Generator.zone.save!
-        parent_id = parent.id.as(String)
-        5.times do
-          Generator.metadata(parent: parent_id).save!
-        end
-        Metadata.build_metadata(parent_id).size.should eq 5
-        parent.destroy
+  describe "for" do
+    it "fetches metadata for a parent" do
+      parent = Generator.zone.save!
+      parent_id = parent.id.as(String)
+      5.times do
+        Generator.metadata(parent: parent_id).save!
       end
+      Metadata.for(parent_id).to_a.size.should eq 5
+      parent.destroy
+    end
+  end
+
+  describe "build_metadata" do
+    it "builds a response of metadata for a parent" do
+      parent = Generator.zone.save!
+      parent_id = parent.id.as(String)
+      5.times do
+        Generator.metadata(parent: parent_id).save!
+      end
+      Metadata.build_metadata(parent_id).size.should eq 5
+      parent.destroy
     end
   end
 end

--- a/spec/metadata_spec.cr
+++ b/spec/metadata_spec.cr
@@ -6,7 +6,7 @@ module PlaceOS::Model
       control_system = Generator.control_system.save!
       meta = Generator.metadata(name: "test", parent: control_system.id.as(String)).save!
 
-      control_system.master_metadata.first.id.should eq meta.id
+      control_system.metadata.first.id.should eq meta.id
 
       meta_find = Metadata.find!(meta.id.as(String))
       meta_find.control_system!.id.should eq control_system.id
@@ -32,7 +32,7 @@ module PlaceOS::Model
       zone = Generator.zone.save!
       meta = Generator.metadata(parent: zone.id.as(String)).save!
 
-      zone.master_metadata.first.id.should eq meta.id
+      zone.metadata.first.id.should eq meta.id
       meta_find = Metadata.find!(meta.id.as(String))
       meta_find.zone!.id.should eq zone.id
 

--- a/spec/metadata_spec.cr
+++ b/spec/metadata_spec.cr
@@ -56,6 +56,21 @@ module PlaceOS::Model
       Metadata.from_json(meta.to_json).details.should eq JSON.parse(object)
     end
 
+    context "validation" do
+      it "ensures `name` is unique beneath `parent_id`, ignoring versions" do
+        parent = Generator.zone.save!
+        parent_id = parent.id.as(String)
+        name = UUID.random.to_s
+        original, duplicate = Array(Metadata).new(2) { Generator.metadata(name: name, parent: parent_id) }
+        puts original, duplicate
+
+        original.save!
+        expect_raises(RethinkORM::Error::DocumentInvalid, /`name` must be unique beneath 'parent_id'/) do
+          duplicate.save!
+        end
+      end
+    end
+
     describe "#history" do
       it "renders versions made on updates to the master Metadata" do
         changes = [0, 1, 2, 3].map { |i| JSON::Any.new({"test" => JSON::Any.new(i.to_i64)}) }

--- a/spec/metadata_spec.cr
+++ b/spec/metadata_spec.cr
@@ -74,7 +74,7 @@ module PlaceOS::Model
       end
 
       it "limits number of stored versions" do
-        changes = Array(JSON::Any).new(2 * Utilities::Versions::MAX_HISTORY) { |i|
+        changes = Array(JSON::Any).new(2 * Utilities::Versions::MAX_VERSIONS) { |i|
           JSON::Any.new({"test" => JSON::Any.new(i.to_i64)})
         }
 
@@ -89,7 +89,7 @@ module PlaceOS::Model
           end
         end
 
-        metadata.history.size.should eq Utilities::Versions::MAX_HISTORY
+        metadata.history.size.should eq Utilities::Versions::MAX_VERSIONS
       end
     end
   end

--- a/spec/module_spec.cr
+++ b/spec/module_spec.cr
@@ -227,10 +227,10 @@ module PlaceOS::Model
         Generator.settings(mod: mod, settings_string: module_settings_string).save!
 
         expected_settings_ids = [
-          mod.master_settings,
-          control_system.master_settings,
-          zone.master_settings,
-          driver.master_settings,
+          mod.settings,
+          control_system.settings,
+          zone.settings,
+          driver.settings,
         ].flat_map(&.compact_map(&.id))
 
         settings_hierarchy_ids = mod.settings_hierarchy.compact_map(&.id)

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -23,7 +23,6 @@ module PlaceOS::Model
       model.control_system = control_system
       model.modified_by = modifier
       model.save
-      puts model.attributes
       model.modified_by_id.should eq(modifier.id)
 
       # Subsequent saves should not have a `modified_by_id` set
@@ -111,8 +110,6 @@ module PlaceOS::Model
       end
 
       settings.history.map(&.any["a"]).should eq [3, 2, 1, 0]
-
-      settings.history(limit: 3).size.should eq 3
     end
 
     describe "#for_parent" do

--- a/spec/utilities/settings_helper_spec.cr
+++ b/spec/utilities/settings_helper_spec.cr
@@ -46,9 +46,7 @@ module PlaceOS::Model
           Generator.settings(parent: model, settings_string: settings_string, encryption_level: level).save!
         end
 
-        level = Encryption::Level.parse(model.all_settings[YAML::Any.new(key)].as_s)
-        pp! level
-        level.none?.should be_true
+        Encryption::Level.parse(model.all_settings[YAML::Any.new(key)].as_s).none?.should be_true
         model.destroy
       end
     end

--- a/spec/utilities/settings_helper_spec.cr
+++ b/spec/utilities/settings_helper_spec.cr
@@ -1,4 +1,4 @@
-require "./helper"
+require "../helper"
 
 module PlaceOS::Model
   macro test_settings(klass)
@@ -30,7 +30,7 @@ module PlaceOS::Model
     end
   end
 
-  describe SettingsHelper do
+  describe Utilities::SettingsHelper do
     test_settings(ControlSystem)
     test_settings(Module)
     test_settings(Zone)
@@ -46,7 +46,9 @@ module PlaceOS::Model
           Generator.settings(parent: model, settings_string: settings_string, encryption_level: level).save!
         end
 
-        Encryption::Level.parse(model.all_settings[YAML::Any.new(key)].as_s).none?.should be_true
+        level = Encryption::Level.parse(model.all_settings[YAML::Any.new(key)].as_s)
+        pp! level
+        level.none?.should be_true
         model.destroy
       end
     end

--- a/src/placeos-models/control_system.cr
+++ b/src/placeos-models/control_system.cr
@@ -8,11 +8,13 @@ require "./converter/time_location"
 require "./base/model"
 require "./settings"
 require "./utilities/settings_helper"
+require "./utilities/metadata_helper"
 
 module PlaceOS::Model
   class ControlSystem < ModelBase
     include RethinkORM::Timestamps
-    include SettingsHelper
+    include Utilities::SettingsHelper
+    include Utilities::MetadataHelper
 
     table :sys
 

--- a/src/placeos-models/control_system.cr
+++ b/src/placeos-models/control_system.cr
@@ -56,7 +56,7 @@ module PlaceOS::Model
     # Encrypted yaml settings, with metadata
     has_many(
       child_class: Settings,
-      collection_name: "settings",
+      collection_name: "settings_and_versions",
       foreign_key: "parent_id",
       dependent: :destroy
     )
@@ -64,7 +64,7 @@ module PlaceOS::Model
     # Metadata belonging to this control_system
     has_many(
       child_class: Metadata,
-      collection_name: "metadata",
+      collection_name: "metadata_and_versions",
       foreign_key: "parent_id",
       dependent: :destroy
     )
@@ -163,7 +163,7 @@ module PlaceOS::Model
     # Control System < Zone/n < Zone/(n-1) < ... < Zone/0
     def settings_hierarchy : Array(Settings)
       # Start with Control System Settings
-      settings = master_settings
+      hierarchy = settings
 
       # Zone Settings
       zone_models = Model::Zone.find_all(self.zones).to_a
@@ -172,13 +172,13 @@ module PlaceOS::Model
         next if (zone = zone_models.find &.id.==(zone_id)).nil?
 
         begin
-          settings.concat(zone.master_settings)
+          hierarchy.concat(zone.settings)
         rescue error
           Log.warn(exception: error) { "failed to merge zone #{zone_id} settings" }
         end
       end
 
-      settings.compact
+      hierarchy.compact
     end
 
     # Callbacks

--- a/src/placeos-models/driver.cr
+++ b/src/placeos-models/driver.cr
@@ -8,7 +8,7 @@ require "./settings"
 module PlaceOS::Model
   class Driver < ModelBase
     include RethinkORM::Timestamps
-    include SettingsHelper
+    include Utilities::SettingsHelper
 
     table :driver
 
@@ -54,7 +54,7 @@ module PlaceOS::Model
 
     belongs_to Repository, foreign_key: "repository_id", presence: true
 
-    # Encrypted yaml settings, with metadata
+    # Encrypted yaml settings
     has_many(
       child_class: Settings,
       collection_name: "settings",

--- a/src/placeos-models/driver.cr
+++ b/src/placeos-models/driver.cr
@@ -57,7 +57,7 @@ module PlaceOS::Model
     # Encrypted yaml settings
     has_many(
       child_class: Settings,
-      collection_name: "settings",
+      collection_name: "settings_and_versions",
       foreign_key: "parent_id",
       dependent: :destroy
     )
@@ -71,7 +71,7 @@ module PlaceOS::Model
     end
 
     def settings_hierarchy : Array(Settings)
-      master_settings
+      settings
     end
 
     # Callbacks

--- a/src/placeos-models/json_schema.cr
+++ b/src/placeos-models/json_schema.cr
@@ -13,8 +13,14 @@ module PlaceOS::Model
 
     has_many(
       child_class: Metadata,
-      collection_name: "metadata",
+      collection_name: "all_metadata",
       foreign_key: "schema_id",
     )
+
+    def metadata
+      Metadata.master_metadata_query do |q|
+        q.filter({schema_id: self.id.as(String)})
+      end
+    end
   end
 end

--- a/src/placeos-models/json_schema.cr
+++ b/src/placeos-models/json_schema.cr
@@ -13,7 +13,7 @@ module PlaceOS::Model
 
     has_many(
       child_class: Metadata,
-      collection_name: "all_metadata",
+      collection_name: "metadata_and_versions",
       foreign_key: "schema_id",
     )
 

--- a/src/placeos-models/json_schema.cr
+++ b/src/placeos-models/json_schema.cr
@@ -18,9 +18,7 @@ module PlaceOS::Model
     )
 
     def metadata
-      Metadata.master_metadata_query do |q|
-        q.filter({schema_id: self.id.as(String)})
-      end
+      Metadata.master_metadata_query(&.filter({schema_id: self.id.as(String)}))
     end
   end
 end

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -43,9 +43,9 @@ module PlaceOS::Model
     validates :name, presence: true
     validates :parent_id, presence: true
 
-    ensure_unique :name, scope: [:parent_id, :name] do |parent_id, name|
-      {parent_id, name.strip.downcase}
-    end
+    # ensure_unique :name, scope: [:parent_id, :name] do |parent_id, name|
+    #   {parent_id, name.strip.downcase}
+    # end
 
     # Queries
     ###############################################################################################
@@ -58,19 +58,17 @@ module PlaceOS::Model
                     parent.id.as(String)
                   end
 
-      Metadata.raw_query do |q|
-        query = q.table(Model::Metadata.table_name).get_all(parent_id, index: :parent_id)
-        if name && !name.empty?
-          query.filter({name: name})
-        else
-          query
-        end
+      master_metadata_query do |q|
+        q = q.get_all(parent_id, index: :parent_id)
+        q = q.filter({name: name}) if name && !name.empty?
+        q
       end
     end
 
     # Generate a version upon save of a master Metadata
     #
     protected def create_version(version : self) : self
+      version.details = details.clone
       version
     end
 

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -4,6 +4,7 @@ require "json"
 
 require "./converter/json_string"
 require "./utilities/last_modified"
+require "./utilities/versions"
 
 require "./base/model"
 require "./control_system"
@@ -13,6 +14,7 @@ module PlaceOS::Model
   class Metadata < ModelBase
     include RethinkORM::Timestamps
     include Utilities::LastModified
+    include Utilities::Versions
 
     table :metadata
 
@@ -64,6 +66,12 @@ module PlaceOS::Model
           query
         end
       end
+    end
+
+    # Generate a version upon save of a master Metadata
+    #
+    protected def create_version(version : self) : self
+      version
     end
 
     # Serialisation

--- a/src/placeos-models/module.cr
+++ b/src/placeos-models/module.cr
@@ -11,7 +11,7 @@ require "./utilities/settings_helper"
 module PlaceOS::Model
   class Module < ModelBase
     include RethinkORM::Timestamps
-    include SettingsHelper
+    include Utilities::SettingsHelper
 
     table :mod
 

--- a/src/placeos-models/module.cr
+++ b/src/placeos-models/module.cr
@@ -58,7 +58,7 @@ module PlaceOS::Model
     # Encrypted yaml settings, with metadata
     has_many(
       child_class: Settings,
-      collection_name: "settings",
+      collection_name: "settings_and_versions",
       foreign_key: "parent_id",
       dependent: :destroy
     )
@@ -198,19 +198,19 @@ module PlaceOS::Model
     # Module > (Control System > Zones) > Driver
     def settings_hierarchy : Array(Settings)
       # Accumulate settings, starting with the Module's
-      settings = master_settings
+      hierarchy = settings
 
       if role.logic?
         cs = self.control_system
         raise Model::Error::NoParent.new("Missing control system: module_id=#{@id} control_system_id=#{@control_system_id}") if cs.nil?
         # Control System < Zone Settings
-        settings.concat(cs.settings_hierarchy)
+        hierarchy.concat(cs.settings_hierarchy)
       end
 
       # Driver Settings
-      settings.concat(self.driver.as(Model::Driver).master_settings)
+      hierarchy.concat(self.driver.as(Model::Driver).settings)
 
-      settings.compact
+      hierarchy.compact
     end
 
     # Merge settings hierarchy to JSON

--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -147,11 +147,24 @@ module PlaceOS::Model
     # Queries
     ###########################################################################
 
-    def self.master_settings_query(ids : String | Array(String))
+    def self.master_settings_query
       previous_def.sort_by! do |setting|
         # Reversed
         -1 * setting.encryption_level.value
       end
+    end
+
+    # Get `Settings` for given parent id/s
+    #
+    def self.for_parent(parent_ids : String | Array(String), &) : Array(self)
+      master_settings_query do |q|
+        yield (q.get_all(parent_ids, index: :parent_id))
+      end
+    end
+
+    # :ditto:
+    def self.for_parent(parent_ids : String | Array(String)) : Array(self)
+      for_parent(parent_ids, &.itself)
     end
 
     # Query all settings under `parent_id`

--- a/src/placeos-models/settings.cr
+++ b/src/placeos-models/settings.cr
@@ -147,18 +147,14 @@ module PlaceOS::Model
     # Queries
     ###########################################################################
 
-    def self.master_settings_query
-      previous_def.sort_by! do |setting|
-        # Reversed
-        -1 * setting.encryption_level.value
-      end
-    end
-
     # Get `Settings` for given parent id/s
     #
     def self.for_parent(parent_ids : String | Array(String), &) : Array(self)
       master_settings_query do |q|
         yield (q.get_all(parent_ids, index: :parent_id))
+      end.sort_by! do |setting|
+        # Reversed
+        -1 * setting.encryption_level.value
       end
     end
 

--- a/src/placeos-models/user.cr
+++ b/src/placeos-models/user.cr
@@ -6,11 +6,14 @@ require "rethinkdb-orm/lock"
 
 require "./base/model"
 require "./api_key"
+require "./metadata"
 require "./email"
+require "./utilities/metadata_helper"
 
 module PlaceOS::Model
   class User < ModelBase
     include RethinkORM::Timestamps
+    include Utilities::MetadataHelper
 
     table :user
 

--- a/src/placeos-models/user.cr
+++ b/src/placeos-models/user.cr
@@ -68,7 +68,7 @@ module PlaceOS::Model
     # Metadata belonging to this user
     has_many(
       child_class: Metadata,
-      collection_name: "metadata",
+      collection_name: "metadata_and_versions",
       foreign_key: "parent_id",
       dependent: :destroy
     )

--- a/src/placeos-models/utilities/last_modified.cr
+++ b/src/placeos-models/utilities/last_modified.cr
@@ -2,6 +2,7 @@ require "rethinkdb-orm"
 
 require "../user"
 
+# Adds modification data to a `PlaceOS::Model`
 module PlaceOS::Model::Utilities::LastModified
   macro included
     attribute modified_at : Time = ->{ Time.utc }, converter: Time::EpochConverter

--- a/src/placeos-models/utilities/metadata_helper.cr
+++ b/src/placeos-models/utilities/metadata_helper.cr
@@ -4,14 +4,8 @@ require "../metadata"
 
 module PlaceOS::Model::Utilities
   module MetadataHelper
-    def master_metadata(name : String? = nil) : Array(Metadata)
+    def metadata(name : String? = nil) : Array(Metadata)
       Metadata.for(self, name)
-    end
-
-    # Attain the metadata associated with the model
-    #
-    def metadata_collection
-      RethinkORM::AssociationCollection(self.class, Metadata).new(self)
     end
   end
 end

--- a/src/placeos-models/utilities/metadata_helper.cr
+++ b/src/placeos-models/utilities/metadata_helper.cr
@@ -1,0 +1,17 @@
+require "rethinkdb-orm"
+
+require "../metadata"
+
+module PlaceOS::Model::Utilities
+  module MetadataHelper
+    def master_metadata(name : String? = nil) : Array(Metadata)
+      Metadata.for(self, name)
+    end
+
+    # Attain the metadata associated with the model
+    #
+    def metadata_collection
+      RethinkORM::AssociationCollection(self.class, Metadata).new(self)
+    end
+  end
+end

--- a/src/placeos-models/utilities/settings_helper.cr
+++ b/src/placeos-models/utilities/settings_helper.cr
@@ -6,17 +6,17 @@ module PlaceOS::Model::Utilities
   module SettingsHelper
     abstract def settings_hierarchy : Array(Settings)
 
-    # Attain the settings associated with the model
+    # Query the master settings attached to a model
     #
-    def settings_collection
-      RethinkORM::AssociationCollection(self.class, Settings).new(self)
+    def settings : Array(Settings)
+      Settings.for_parent(self.id.as(String))
     end
 
     # Get the settings at a particular encryption level
     #
     def settings_at(encryption_level : Encryption::Level)
-      raise IndexError.new unless (settings = settings_at?(encryption_level))
-      settings
+      raise IndexError.new unless (settings_at_level = settings_at?(encryption_level))
+      settings_at_level
     end
 
     # Get the settings at a particular encryption level
@@ -31,13 +31,13 @@ module PlaceOS::Model::Utilities
     #
     # Lower privilged settings are favoured during the merge process.
     def all_settings : Hash(YAML::Any, YAML::Any)
-      master_settings
-        .each_with_object({} of YAML::Any => YAML::Any) do |settings, acc|
+      settings
+        .each_with_object({} of YAML::Any => YAML::Any) do |setting, acc|
           # Parse and merge into accumulated settings hash
           begin
-            acc.merge!(settings.any)
+            acc.merge!(setting.any)
           rescue error
-            Log.warn(exception: error) { "failed to merge all settings: #{settings.inspect}" }
+            Log.warn(exception: error) { "failed to merge all settings: #{setting.inspect}" }
           end
         end
     end
@@ -46,12 +46,6 @@ module PlaceOS::Model::Utilities
     #
     def settings_json : String
       all_settings.to_json
-    end
-
-    # Query the master settings attached to a model
-    #
-    def master_settings : Array(Settings)
-      Settings.for_parent(self.id.as(String))
     end
   end
 end

--- a/src/placeos-models/utilities/settings_helper.cr
+++ b/src/placeos-models/utilities/settings_helper.cr
@@ -2,7 +2,7 @@ require "rethinkdb-orm"
 
 require "../settings"
 
-module PlaceOS::Model
+module PlaceOS::Model::Utilities
   module SettingsHelper
     abstract def settings_hierarchy : Array(Settings)
 
@@ -22,7 +22,7 @@ module PlaceOS::Model
     # Get the settings at a particular encryption level
     #
     def settings_at?(encryption_level : Encryption::Level)
-      Settings.master_settings_query(self.id.as(String)) do |q|
+      Settings.for_parent(self.id.as(String)) do |q|
         q.filter({encryption_level: encryption_level.to_i})
       end.first?
     end
@@ -51,7 +51,7 @@ module PlaceOS::Model
     # Query the master settings attached to a model
     #
     def master_settings : Array(Settings)
-      Settings.master_settings_query(self.id.as(String), &.itself)
+      Settings.for_parent(self.id.as(String))
     end
   end
 end

--- a/src/placeos-models/utilities/versions.cr
+++ b/src/placeos-models/utilities/versions.cr
@@ -3,7 +3,7 @@ require "rethinkdb-orm"
 # Adds version history to a `PlaceOS::Model`
 module PlaceOS::Model::Utilities::Versions
   # Number of version models to retain
-  MAX_HISTORY = 20
+  MAX_VERSIONS = (ENV["PLACE_MAX_VERSIONS"]?.try(&.to_i?) || 20)
 
   macro included
     {% klass_name = @type.id.split("::").last.underscore.id %}
@@ -57,7 +57,7 @@ module PlaceOS::Model::Utilities::Versions
 
       ::RethinkORM::Connection.raw do |q|
         master_query(q, &.itself)
-          .slice(MAX_HISTORY)
+          .slice(MAX_VERSIONS)
           .delete
       end
     end

--- a/src/placeos-models/utilities/versions.cr
+++ b/src/placeos-models/utilities/versions.cr
@@ -1,0 +1,89 @@
+require "rethinkdb-orm"
+
+# Adds version history to a `PlaceOS::Model`
+module PlaceOS::Model::Utilities::Versions
+  macro included
+    {% klass_name = @type.id.split("::").last.underscore.id %}
+    {% parent_id = "#{klass_name}_id".id %}
+
+    attribute {{ parent_id }} : String?
+    secondary_index {{ parent_id.symbolize }}
+
+    # {{ @type }} self-referential entity relationship acts as a 2-level tree
+    has_many(
+      child_class: {{ @type }},
+      collection_name: {{ klass_name.stringify }},
+      foreign_key: {{ parent_id.stringify }},
+      dependent: :destroy
+    )
+
+    # If a {{ @type }} has a parent, it's a version
+    def is_version? : Bool
+      !{{ parent_id }}.nil?
+    end
+
+    # Callbacks
+    ###########################################################################
+
+    after_save :__create_version__
+
+    protected def __create_version__
+      return if is_version?
+
+      saved_created = created_at
+      saved_updated = updated_at
+
+      @created_at = nil
+      @updated_at = nil
+
+      version = self.dup
+      version.id = nil
+      version.{{ parent_id }} = self.id
+      if version.responds_to? :modified_by && self.responds_to? :modified_by
+        version.modified_by = self.modified_by.as(User)
+      end
+      create_version(version).save!
+
+      self.created_at = saved_created
+      self.updated_at = saved_updated
+    end
+
+    # Queries
+    ###########################################################################
+
+    # Get version history
+    #
+    # Versions are in descending order of creation
+    def history(offset : Int32 = 0, limit : Int32 = 10)
+      {{ @type }}.raw_query do |r|
+        r
+          .table({{ @type }}.table_name)
+          .get_all([parent_id.as(String)], index: :parent_id)
+          .filter({
+            {{ parent_id }}: id.as(String)
+          })
+          .order_by(r.desc(:created_at)).slice(offset, offset + limit)
+      end.to_a
+    end
+
+    # Get {{ @type }} for given parent id/s
+    #
+    def self.for_parent(parent_ids : String | Array(String)) : Array(self)
+      master_{{ klass_name }}_query(parent_ids, &.itself)
+    end
+
+    # Query on master {{ klass_name }} associated with ids
+    #
+    # Gets documents where the {{ parent_id }} does not exist, i.e. is the master
+    def self.master_{{ klass_name }}_query(ids : String | Array(String))
+      cursor = query(ids) do |q|
+        yield q.filter(&.has_fields({{ parent_id.symbolize }}).not)
+      end
+
+      cursor.to_a
+    end
+  end
+
+  # Make relevant updates to version before it is saved
+  abstract def create_version(version : self) : self
+end

--- a/src/placeos-models/zone.cr
+++ b/src/placeos-models/zone.cr
@@ -61,7 +61,7 @@ module PlaceOS::Model
     # Metadata belonging to this zone
     has_many(
       child_class: Metadata,
-      collection_name: "metadata",
+      collection_name: "metadata_and_versions",
       foreign_key: "parent_id",
       dependent: :destroy
     )
@@ -69,7 +69,7 @@ module PlaceOS::Model
     # Encrypted yaml settings
     has_many(
       child_class: Settings,
-      collection_name: "settings",
+      collection_name: "settings_and_versions",
       foreign_key: "parent_id",
       dependent: :destroy
     )
@@ -150,7 +150,7 @@ module PlaceOS::Model
     ###########################################################################
 
     def settings_hierarchy : Array(Settings)
-      master_settings
+      settings
     end
 
     def self.with_tag(tag : String)

--- a/src/placeos-models/zone.cr
+++ b/src/placeos-models/zone.cr
@@ -4,11 +4,13 @@ require "time"
 require "./base/model"
 require "./settings"
 require "./utilities/settings_helper"
+require "./utilities/metadata_helper"
 
 module PlaceOS::Model
   class Zone < ModelBase
     include RethinkORM::Timestamps
-    include SettingsHelper
+    include Utilities::SettingsHelper
+    include Utilities::MetadataHelper
 
     table :zone
 


### PR DESCRIPTION
**Description of the change**

- Adds a generalised model version module
- Adds generalised history module to `Metadata`

**Benefits**

Generalises the logic of versions, and makes it simpler to add versioning to a model

**Possible drawbacks**

- Queries in the model will need to be scoped to ensure that versions don't pollute the queries for master versions.
- Changes to interface: `master_settings` is now `settings`
- Changes to interface: `settings` is now `settings_and_versions`

**Applicable issues**

- Closes #150
- Closes #151 