### PR TITLE
fix(versions#history): restore `offset` and `limit`

### DIFF
--- a/spec/metadata_spec.cr
+++ b/spec/metadata_spec.cr
@@ -104,7 +104,8 @@ module PlaceOS::Model
           end
         end
 
-        metadata.history.size.should eq Utilities::Versions::MAX_VERSIONS
+        metadata.history(limit: 2).size.should eq 2
+        metadata.history(limit: 1000).size.should eq Utilities::Versions::MAX_VERSIONS
       end
     end
   end


### PR DESCRIPTION
**Description of the change**

Returns `offset` and `limit` to prevent breaking the API interface, and support larger history sizes.

**Benefits**

Keeps interface stable