### PR TITLE
feat(metadata): add `Metadata.build_history`

### DIFF
--- a/spec/user_spec.cr
+++ b/spec/user_spec.cr
@@ -24,7 +24,7 @@ module PlaceOS::Model
     describe "before_destroy" do
       context "ensure_admin_remains" do
         it "protects against concurrent deletes of admins" do
-          num_tests = 30
+          num_tests = 15
           errors = [] of Model::Error
           num_tests.times do
             User.clear

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -1,6 +1,7 @@
+require "json"
+require "openapi-generator/serializable"
 require "rethinkdb-orm"
 require "time"
-require "json"
 
 require "./converter/json_string"
 require "./utilities/last_modified"
@@ -137,6 +138,7 @@ module PlaceOS::Model
       created_at : Time,
     ) do
       include JSON::Serializable
+      extend OpenAPI::Generator::Serializable
 
       @[JSON::Field(converter: Time::EpochConverter)]
       @updated_at : Time

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -125,24 +125,48 @@ module PlaceOS::Model
     # Serialisation
     ###############################################################################################
 
-    record Interface, name : String, description : String, details : JSON::Any, editors : Set(String)?, parent_id : String?, id : String? {
+    record(
+      Interface,
+      name : String,
+      description : String,
+      details : JSON::Any,
+      editors : Set(String)?,
+      parent_id : String?,
+      modified_by_id : String?,
+      updated_at : Time,
+      created_at : Time,
+    ) do
       include JSON::Serializable
-    }
+
+      @[JSON::Field(converter: Time::EpochConverter)]
+      @updated_at : Time
+      @[JSON::Field(converter: Time::EpochConverter)]
+      @created_at : Time
+    end
 
     def self.interface(model : Metadata)
+      {% begin %}
       Interface.new(
-        name: model.name,
-        description: model.description,
-        details: model.details,
-        parent_id: model.parent_id,
-        editors: model.editors,
-        id: model.id,
+        {% for instance_variable in Model::Metadata::Interface.instance_vars %}
+          {{ instance_variable.name }}: model.{{ instance_variable.name }},
+        {% end %}
       )
+      {% end %}
+    end
+
+    def interface
+      self.class.interface(self)
     end
 
     def self.build_metadata(parent, name : String? = nil) : Hash(String, Interface)
       for(parent, name).each_with_object({} of String => Interface) do |data, results|
-        results[data.name] = self.interface(data)
+        results[data.name] = data.interface
+      end
+    end
+
+    def self.build_history(parent, name : String? = nil, offset : Int32 = 0, limit : Int32 = 10)
+      for(parent, name).each_with_object({} of String => Array(Interface)) do |data, results|
+        results[data.name] = data.history(offset, limit).map(&.interface)
       end
     end
   end

--- a/src/placeos-models/utilities/last_modified.cr
+++ b/src/placeos-models/utilities/last_modified.cr
@@ -5,8 +5,6 @@ require "../user"
 # Adds modification data to a `PlaceOS::Model`
 module PlaceOS::Model::Utilities::LastModified
   macro included
-    attribute modified_at : Time = ->{ Time.utc }, converter: Time::EpochConverter
-
     has_one User, association_name: :modified_by
 
     @modified_by : User?
@@ -17,16 +15,14 @@ module PlaceOS::Model::Utilities::LastModified
       end
     end
 
-    before_save :set_modified_at
+    before_save :set_modified_by
     after_save :clear_modifier
 
-    protected def set_modified_at
+    protected def set_modified_by
       unless self.modified_by_id_changed?
         Log.debug { "No modifying user recorded for #{self.id}" }
         self.modified_by_id = nil
       end
-
-      self.modified_at = Time.utc
     end
 
     protected def clear_modifier


### PR DESCRIPTION
**Description of the change**

Conform `Metadata` history response to other `Metadata` responses, i.e. an object keyed by `name` with values of the desired response.
 
**Benefits**

Prevent awkward API change by addition of `id` in the `Metadata::Interface` in #157 