### PR TITLE
fix(metadata): skip parent validation if no `parent_id`

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,5 +1,10 @@
 name: Validate PR
-on: pull_request
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
 
 jobs:
   title:

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -53,6 +53,8 @@ module PlaceOS::Model
     def self.validate_parent_exists(metadata : Metadata)
       # Skip validation if `Metadata` has been created
       return unless metadata.id.nil?
+      # `parent_id` presence is already enforced
+      return if metadata.parent_id.nil?
 
       table_name = metadata.parent_id.as(String).partition('-').first
       if RethinkORM::Connection.raw(&.table(table_name).get(metadata.parent_id)).raw.nil?


### PR DESCRIPTION
**Description of the change**

Validation was breaking due to a cast in the `validate_parent_exists` validation