### PR TITLE
fix(metadata#query): allow `@` and ` ` in keys and values

### DIFF
--- a/spec/metadata_spec.cr
+++ b/spec/metadata_spec.cr
@@ -220,7 +220,7 @@ module PlaceOS::Model
           end
         in .equals?
           key_paths = {"one", "one.two"}
-          mock_value = UUID.random.to_s
+          mock_value = "#{UUID.random}@evil.corp"
           before_all do
             mock_details = {
               {
@@ -240,8 +240,10 @@ module PlaceOS::Model
 
           key_paths.each_with_index(offset: 1) do |path, depth|
             it "matches values at key depth of #{depth}" do
+              # Ensure that queries with URI encoded values work
+              query = Metadata::Query.from_param?("equals[#{path}]", URI.encode_www_form(mock_value)).not_nil!
               Metadata
-                .query([Metadata::Query::Equals.new(path, mock_value)])
+                .query([query])
                 .tap(&.size.should eq(1))
                 .first.tap do |metadata|
                 path.split('.').reduce(metadata.details) do |object, key|

--- a/spec/metadata_spec.cr
+++ b/spec/metadata_spec.cr
@@ -252,7 +252,8 @@ module PlaceOS::Model
           end
         in .starts_with?
           key_paths = {"one", "one.two"}
-          mock_value = UUID.random.to_s
+          mock_value = "^.#{UUID.random}"
+
           before_all do
             mock_details = {
               {

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -163,7 +163,7 @@ module PlaceOS::Model
 
       # Restrict the values/keys to a safe set of characters
       protected class_getter param_string_parser : Pars::Parser(String) do
-        param_safe_char_parser = Pars::Parse.alphanumeric | Pars::Parse.one_char_of({'-', '.', '_', '~'})
+        param_safe_char_parser = Pars::Parse.alphanumeric | Pars::Parse.one_char_of({'-', '.', '_', '~', '@', ' '})
         (param_safe_char_parser * (1..)).map &.join
       end
 
@@ -178,6 +178,10 @@ module PlaceOS::Model
 
       # ameba:disable Metrics/CyclomaticComplexity
       def self.from_param?(param_key : String, param_value : String?)
+        # Ensure that arguments have been URI decoded
+        param_key = URI.decode_www_form(param_key)
+        param_value = URI.decode_www_form(param_value) if param_value
+
         return unless parsed = parse?(param_key, param_value)
         type, key, value = parsed[:type], parsed[:key], parsed[:value]
 

--- a/src/placeos-models/metadata.cr
+++ b/src/placeos-models/metadata.cr
@@ -141,6 +141,26 @@ module PlaceOS::Model
         end
       end
 
+      protected def self.escape_regex(value : String)
+        value.gsub({
+          "\\\\": %q(\\\\),
+          "\\":   %q(\\),
+          "^":    "\\^",
+          "$":    "\\$",
+          ".":    "\\.",
+          "|":    "\\|",
+          "?":    "\\?",
+          "*":    "\\*",
+          "+":    "\\+",
+          "(":    "\\(",
+          ")":    "\\)",
+          "[":    "\\[",
+          "]":    "\\]",
+          "{":    "\\{",
+          "}":    "\\}",
+        })
+      end
+
       # Restrict the values/keys to a safe set of characters
       protected class_getter param_string_parser : Pars::Parser(String) do
         param_safe_char_parser = Pars::Parse.alphanumeric | Pars::Parse.one_char_of({'-', '.', '_', '~'})
@@ -287,7 +307,7 @@ module PlaceOS::Model
         def apply(query_builder)
           query_builder.filter do |document|
             lookup_key(document) do |lookup|
-              lookup.match("^#{value}")
+              lookup.match("^#{self.class.escape_regex(value)}")
             end
           end
         end


### PR DESCRIPTION
**Description of the change**

- Ensure that special regex characters are escaped
- URI decode params in the parse step
- Allow `@` and ` ` after decoding

This fixes the previously broken equals query.