### PR TITLE
feat(edge): add `#to_key_json`

### DIFF
--- a/src/placeos-models/edge.cr
+++ b/src/placeos-models/edge.cr
@@ -23,6 +23,8 @@ module PlaceOS::Model
 
     CONTROL_SCOPE = "edge-control"
 
+    define_to_json :key, methods: :x_api_key
+
     # Creation
     ###############################################################################################
 


### PR DESCRIPTION
**Description of the change**

Allow passing of the `x_api_key` field in the response for edge creation but don't persist it in the edge model.

**Benefits**

Backoffice (and any other frontend) will be able to display the api key to the user upon creation of an edge.
