### PR TITLE
feat(metadata): add pagination

### DIFF
--- a/src/placeos-models/utilities/versions.cr
+++ b/src/placeos-models/utilities/versions.cr
@@ -1,5 +1,16 @@
 require "rethinkdb-orm"
 
+# TODO: Add `RethinkDB::StreamTerm#slice` to `crystal-rethinkdb`
+class RethinkDB::StreamTerm
+  def slice(start)
+    StreamTerm.new(TermType::SLICE, [self, start])
+  end
+
+  def slice(start, size)
+    StreamTerm.new(TermType::SLICE, [self, start, size])
+  end
+end
+
 # Adds version history to a `PlaceOS::Model`
 module PlaceOS::Model::Utilities::Versions
   # Number of version models to retain
@@ -102,18 +113,22 @@ module PlaceOS::Model::Utilities::Versions
     # Query on main {{ klass_name }} documents
     #
     # Gets documents where the {{ parent_id }} does not exist, i.e. is the main
-    def self.master_{{ klass_name }}_query
+    def self.master_{{ klass_name }}_query(offset : Int32 = 0, limit : Int32 = 100)
       raw_query do |q|
-        (yield q.table(table_name)).filter(&.has_fields({{ parent_id.symbolize }}).not)
+        (yield q.table(table_name))
+          .filter(&.has_fields({{ parent_id.symbolize }}).not)
+          .slice(offset, offset + limit)
       end.to_a
     end
 
     # Query on main {{ klass_name }} documents
     #
     # Gets documents where the {{ parent_id }} does not exist, i.e. is the main
-    def self.master_{{ klass_name }}_raw_query
+    def self.master_{{ klass_name }}_raw_query(offset : Int32 = 0, limit : Int32 = 100)
       ::RethinkORM::Connection.raw do |q|
-        (yield q.table(table_name)).filter(&.has_fields({{ parent_id.symbolize }}).not)
+        (yield q.table(table_name))
+          .filter(&.has_fields({{ parent_id.symbolize }}).not)
+          .slice(offset, offest + limit)
       end
     end
   end


### PR DESCRIPTION
**Description of the change**

Adds pagination to `Metadata.query`. Also corrects some potential unexpected behaviour with negative pagination ranges.

**Benefits**

Paged results for Metadata queries.

**Applicable issues**

- https://github.com/PlaceOS/rest-api/issues/263