### PR TITLE
feat(repository): add deployed_commit_hash

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 8.7.0
+version: 8.8.0
 crystal: ~> 1.0
 
 dependencies:

--- a/src/placeos-models/repository.cr
+++ b/src/placeos-models/repository.cr
@@ -22,7 +22,7 @@ module PlaceOS::Model
     attribute uri : String
     attribute commit_hash : String = "HEAD"
     attribute branch : String = "master"
-    attribute deployed_commit_hash : String? = nil
+    attribute deployed_commit_hash : String? = nil, mass_assignment: false
 
     # Whether the repository is pinned to a release asset
     attribute release : Bool = false

--- a/src/placeos-models/repository.cr
+++ b/src/placeos-models/repository.cr
@@ -22,6 +22,7 @@ module PlaceOS::Model
     attribute uri : String
     attribute commit_hash : String = "HEAD"
     attribute branch : String = "master"
+    attribute deployed_commit_hash : String? = nil
 
     # Whether the repository is pinned to a release asset
     attribute release : Bool = false


### PR DESCRIPTION
for differentiating between the target `commit_hash` and what is currently in place.
This allows interfaces to remain at `HEAD` with only changes to `deployed_commit_hash` occuring for feedback
