### PR TITLE
fix(repository): pull! should use deployed_commit_hash

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 8.8.0
+version: 8.8.1
 crystal: ~> 1.0
 
 dependencies:

--- a/src/placeos-models/repository.cr
+++ b/src/placeos-models/repository.cr
@@ -109,16 +109,8 @@ module PlaceOS::Model
 
     def pull!
       commit_hash_will_change!
-      self.commit_hash = self.class.pull_commit(self)
+      self.deployed_commit_hash = nil
       save!
-    end
-
-    def should_pull?
-      self.commit_hash == self.class.pull_commit(self)
-    end
-
-    def self.pull_commit(repo : Repository)
-      repo.repo_type.driver? ? "HEAD" : "PULL"
     end
   end
 end


### PR DESCRIPTION
deployed_commit_hash for indicating the current commit level
we keep commit_hash_will_change as deployed_commit_hash might already be nil and commit_hash is the important bit of information
