### PR TITLE
fix(executable): short commit

### DIFF
--- a/src/placeos-models/executable.cr
+++ b/src/placeos-models/executable.cr
@@ -79,8 +79,9 @@ module PlaceOS::Model
       Path[entrypoint].basename.rchop(".cr")
     end
 
+    # The default short commit hash is 7 characters
     def self.normalized_commit(commit : String)
-      commit[0, 6]
+      commit[0, 7]
     end
 
     def self.encoded_directory(entrypoint)

--- a/src/placeos-models/executable.cr
+++ b/src/placeos-models/executable.cr
@@ -27,6 +27,7 @@ module PlaceOS::Model
 
     def initialize(@entrypoint, @commit, @digest, crystal_version)
       crystal_version = crystal_version.value if crystal_version.is_a? Shards::Version
+      @commit = self.class.normalized_commit(@commit)
       @crystal_version = SemanticVersion.parse(crystal_version)
     end
 
@@ -40,7 +41,7 @@ module PlaceOS::Model
       end
 
       @entrypoint = File.join(directory, "#{name}.cr")
-      @commit = commit
+      @commit = self.class.normalized_commit(commit)
       @digest = digest
       @crystal_version = crystal_version
     end
@@ -61,7 +62,7 @@ module PlaceOS::Model
     end
 
     def to_s(io)
-      io << "Driver(" << entrypoint << '@' << commit[0, 6]
+      io << "Driver(" << entrypoint << '@' << commit
       io << ", digest=" << digest
       io << ", crystal=" << crystal_version
       io << ")"
@@ -78,6 +79,10 @@ module PlaceOS::Model
       Path[entrypoint].basename.rchop(".cr")
     end
 
+    def self.normalized_commit(commit : String)
+      commit[0, 6]
+    end
+
     def self.encoded_directory(entrypoint)
       Base64.urlsafe_encode(Path[entrypoint].dirname, padding: false)
     end
@@ -87,7 +92,7 @@ module PlaceOS::Model
     def self.glob(entrypoint : String?, commit : String?, digest : String?, crystal_version : SemanticVersion | String?)
       {
         entrypoint.try &->name(String),
-        commit,
+        commit.try &->normalized_commit(String),
         digest,
         crystal_version,
         entrypoint.try &->encoded_directory(String),


### PR DESCRIPTION
**Description of the change**

Limits the length of the commit hash to 7 chars.

**Benefits**

Normalizes lookups