### PR TITLE
chore(authority): add default_app to config

### DIFF
--- a/src/placeos-models/authority.cr
+++ b/src/placeos-models/authority.cr
@@ -22,7 +22,9 @@ module PlaceOS::Model
     attribute logout_url : String = "/auth/logout"
 
     attribute internals : Hash(String, JSON::Any) = {} of String => JSON::Any
-    attribute config : Hash(String, JSON::Any) = {} of String => JSON::Any
+    attribute config : Hash(String, JSON::Any) = {
+      "default_app" => JSON::Any.new("/backoffice/")
+    }
 
     macro finished
       # Ensure only the host is saved.

--- a/src/placeos-models/authority.cr
+++ b/src/placeos-models/authority.cr
@@ -23,7 +23,7 @@ module PlaceOS::Model
 
     attribute internals : Hash(String, JSON::Any) = {} of String => JSON::Any
     attribute config : Hash(String, JSON::Any) = {
-      "default_app" => JSON::Any.new("/backoffice/")
+      "default_app" => JSON::Any.new("/backoffice/"),
     }
 
     macro finished


### PR DESCRIPTION
**Description of the change**

Adds `default_app` with default of `/backoffice/` when creating a domain

**Benefits**

Avoids having to manually set it.
Kubernetes ingress overrides which currently handle this will be removed.

**Applicable issues**

https://acaprojects.atlassian.net/browse/PPT-108


