### PR TITLE
fix: merge commit fb436e breaks asset and asset_instance

### DIFF
--- a/src/placeos-models/asset.cr
+++ b/src/placeos-models/asset.cr
@@ -10,7 +10,7 @@ module PlaceOS::Model
     attribute category : String = ""
     attribute description : String = ""
 
-    attribute purchase_date : Time, converter: Time::EpochConverter, type: "integer", format: "Int64"
+    attribute purchase_date : Time, converter: PlaceOS::Model::Timestamps::EpochConverter, type: "integer", format: "Int64"
     attribute good_until_date : Time?, converter: Time::EpochConverter, type: "integer", format: "Int64"
 
     attribute identifier : String?

--- a/src/placeos-models/asset_instance.cr
+++ b/src/placeos-models/asset_instance.cr
@@ -22,8 +22,8 @@ module PlaceOS::Model
     attribute requester_id : String?
     attribute zone_id : String?
 
-    attribute usage_start : Time, converter: Time::EpochConverter, type: "integer", format: "Int64"
-    attribute usage_end : Time, converter: Time::EpochConverter, type: "integer", format: "Int64"
+    attribute usage_start : Time, converter: PlaceOS::Model::Timestamps::EpochConverter, type: "integer", format: "Int64"
+    attribute usage_end : Time, converter: PlaceOS::Model::Timestamps::EpochConverter, type: "integer", format: "Int64"
 
     # Association
     ################################################################################################


### PR DESCRIPTION
Merge commit https://github.com/PlaceOS/models/commit/fb436e5bb2a6f0dbf201dd25ef8d3c2994f09262 breaks `asset.cr` and `asset_instance.cr`. This PR is to revert changes made to these two files.

- `Time::EpochConverter` returns a `Time?` so it will break on attributes which doesn't use (Type | Nil) union.
- `PlaceOS::Model::Timestamps::EpochConverter` returns a `Time`, so it should be used for attributes which are not expecting any nil value.

