### PR TITLE
feat: added to_rs method and support for dealing with nilable value in EnumConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v9.0.3 (2023-04-17)
+
+### Feat
+
+- **base/model**: added to_rs method
+- **converter/json_string**: added support for dealing with nilable value
+  
 ## v9.0.2 (2023-03-21)
 
 ### Fix

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-models
-version: 9.0.2
+version: 9.0.3
 crystal: ~> 1.4
 
 dependencies:

--- a/src/placeos-models/base/model.cr
+++ b/src/placeos-models/base/model.cr
@@ -114,6 +114,10 @@ module PlaceOS::Model
     def self.to_json(val : T | Nil, builder)
       val.try &.to_json(builder)
     end
+
+    def self.to_rs(val : T | Nil)
+      val.try &.value
+    end
   end
 end
 

--- a/src/placeos-models/converter/json_string.cr
+++ b/src/placeos-models/converter/json_string.cr
@@ -46,4 +46,13 @@ module Enum::ValueConverter(T)
   def self.from_rs(rs : ::DB::ResultSet)
     T.from_value(rs.read(Int32))
   end
+
+  def self.to_json(val : T | Nil)
+    return nil if val.nil?
+    previous_def
+  end
+
+  def self.to_json(val : T | Nil, builder)
+    val.try &.to_json(builder)
+  end
 end


### PR DESCRIPTION
* updated to latest `active-model` and `pg-orm` shard
* added support to deal with nilable values in `EnumConverter`
* added `to_rs` method to separate dealing with to_json and persistence to DB
* bumped minor version

PR to deal with changes in `pg-orm`. 